### PR TITLE
Add prompt engineering resources

### DIFF
--- a/docs/additional-resources.md
+++ b/docs/additional-resources.md
@@ -124,4 +124,5 @@ These references track emerging threats and defence research through 2026 and ar
 - [AI-Powered Fuzzing: Breaking the Bug Hunting Barrier](https://security.googleblog.com/2023/08/ai-powered-fuzzing-breaking-bug-hunting.html)
 - [Evaluating Large Language Models for Enhanced Fuzzing](https://ieeexplore.ieee.org/document/10731701)
 - [Prompt Injection Resources 2026](prompt-dialogue/prompt-injection-resources-2026.md)
+- [Prompt Engineering Attack Resources 2026](prompt-dialogue/prompt-engineering-resources-2026.md)
 - [Fuzzing Resources 2026](fuzzing/fuzzing-resources-2026.md)

--- a/docs/prompt-dialogue/prompt-engineering-resources-2026.md
+++ b/docs/prompt-dialogue/prompt-engineering-resources-2026.md
@@ -1,0 +1,23 @@
+---
+title: "Prompt Engineering Attack Resources 2026"
+category: "Prompt Dialogue"
+source_url: ""
+date_collected: 2025-06-18
+license: "CC-BY-4.0"
+---
+
+The following references build on the original catalog with recent research and blog posts on prompt engineering-based attacks and defenses.
+
+- [Defending Against Indirect Prompt Injection Attacks With Spotlighting](https://arxiv.org/abs/2403.14720)
+- [RAPIDRESPONSE: Mitigating LLM Jailbreaks with a Few Examples](http://arxiv.org/pdf/2411.07494)
+- [Open Sesame! Universal Black-Box Jailbreaking of Large Language Models](http://arxiv.org/pdf/2309.01446)
+- [Effective Prompt Extraction from Language Models](http://arxiv.org/abs/2307.06865)
+- [ASETF: A Novel Method for Jailbreak Attack on LLMs through Translate Suffix Embeddings](https://arxiv.org/abs/2402.16006)
+- [InputSnatch: Stealing Input in LLM Services via Timing Side-Channel Attacks](http://arxiv.org/pdf/2411.18191)
+- [Jailbreaking Attack against Multimodal Large Language Model](https://arxiv.org/abs/2402.02309)
+- [Jailbreak Attacks and Defenses Against Large Language Models: A Survey](https://arxiv.org/abs/2407.04295)
+- [Virtual Context: Enhancing Jailbreak Attacks with Special Token Injection](https://arxiv.org/abs/2406.19845)
+- [Catastrophic Jailbreak of Open-source LLMs via Exploiting Generation](https://arxiv.org/abs/2310.06987)
+- [From LLMs to MLLMs: Exploring the Landscape of Multimodal Jailbreaking](https://arxiv.org/abs/2406.14859v1)
+- [Jailbreaking ChatGPT via Prompt Engineering: An Empirical Study](https://arxiv.org/abs/2305.13860)
+- [Prompt Guard: Meta's Injection and Jailbreak Filter](https://ai.meta.com/blog/meta-llama-3-1-ai-responsibility)


### PR DESCRIPTION
## Summary
- add a new markdown page for 2026 prompt engineering attack resources
- link to the new page from `additional-resources.md`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6853d639d7c0832083302070122b69be