### PR TITLE
Add model-specific attack references

### DIFF
--- a/docs/llm-attack-catalog.md
+++ b/docs/llm-attack-catalog.md
@@ -230,6 +230,8 @@ An indirect jailbreak approach [^1_40]:
 
 ### Model-Specific Attacks
 
+Additional papers are listed in [Model-Specific LLM Attack Resources](model-specific/model-specific-resources.md).
+
 #### Backdoor Attacks
 
 Inserting vulnerabilities into models [^1_41][^1_42]:

--- a/docs/model-specific/model-specific-resources.md
+++ b/docs/model-specific/model-specific-resources.md
@@ -1,0 +1,16 @@
+---
+title: "Model-Specific LLM Attack Resources"
+category: "Model-Specific"
+source_url: ""
+date_collected: 2025-06-18
+license: "CC-BY-4.0"
+---
+
+This page lists additional academic papers and reports focusing on attacks or defenses that depend on the internals of a particular model.
+
+- [Simulate and Eliminate: Revoke Backdoors for Generative Large Language Models](https://arxiv.org/abs/2409.12527)
+- [DemonAgent: Dynamically Encrypted Multi-Backdoor Implantation Attack on LLM-based Agent](https://arxiv.org/abs/2405.17583)
+- [MEGen: Generative Backdoor in Large Language Models via Model Editing](https://arxiv.org/abs/2403.09727)
+- [Research about the Ability of LLM in the Tamper-Detection Area](https://arxiv.org/abs/2307.04536)
+- [TaMPERing with Large Language Models: A Field Guide for Using Generative AI in Public Administration Research](https://arxiv.org/abs/2305.19148)
+- [TextSleuth: Towards Explainable Tampered Text Detection](https://arxiv.org/abs/2311.09491)


### PR DESCRIPTION
## Summary
- document model-specific LLM attack papers
- link to new resource list from the catalog

## Testing
- `FAST_LINK_CHECK=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d7a1937883209ebbc24931e8090f