### PR TITLE
Add gradient-based attack resources

### DIFF
--- a/docs/additional-resources.md
+++ b/docs/additional-resources.md
@@ -51,6 +51,10 @@ Below is a curated set of external articles, blog posts and reports that further
 - [Gradient-based Adversarial Attacks against Text Transformers](https://blogs.night-wolf.io/gradient-based-adversarial-attacks-against-text-transformers)
 - [Uncovering Gradient Inversion Risks in Practical Language Model Training](https://dl.acm.org/doi/abs/10.1145/3658644.3690292)
 
+- [AutoDAN: Interpretable Gradient-Based Adversarial Attacks on Large Language Models](https://arxiv.org/abs/2310.15140)
+- [AutoDAN: Generating Stealthy Jailbreak Prompts on Aligned LLMs](https://arxiv.org/abs/2310.04451)
+- [PIG: Privacy Jailbreak Attack on LLMs via Gradient-based Iterative In-Context Optimization](https://arxiv.org/abs/2505.09921)
+- [Universal and Transferable Adversarial Attacks on Aligned Language Models](https://arxiv.org/abs/2307.15043)
 Additional references collected after the original snapshot:
 
 - [Securing LLM Systems Against Prompt Injection](https://developer.nvidia.com/blog/securing-llm-systems-against-prompt-injection/)

--- a/docs/llm-attack-catalog.md
+++ b/docs/llm-attack-catalog.md
@@ -103,6 +103,14 @@ An advanced version of GCG that generates customized suffixes [^1_21]:
 - **Generative Suffix Model**: A model trained to generate many customized suffixes for harmful queries in seconds [^1_21].
 - **Perplexity Detector Bypass**: Techniques to evade detection mechanisms while maintaining high attack success rates [^1_21].
 - [AmpleGCG GitHub repo](optimization/amplegcg-repo.html) - open-source implementation of customized suffix attack.
+#### AutoDAN
+
+A gradient-guided attack that iteratively modifies prompts to bypass safety filters while preserving semantics [^27].
+
+#### PIG
+
+An in-context jailbreak approach that tunes examples via gradient signals to leak private data [^28].
+
 
 
 ### Fuzzing Techniques
@@ -752,3 +760,5 @@ Your catalog is now aligned with every peer-reviewed or industry-grade threat pu
 [24]: https://www.usenix.org/system/files/conference/usenixsecurity25/sec25cycle1-prepub-746-villa.pdf "Exposing the Guardrails: Reverse-Engineering and Jailbreaking Safety Filters in DALL·E Text-to-Image Pipelines"
 [25]: https://arxiv.org/html/2502.14182v1 "Multi-Faceted Studies on Data Poisoning"
 [26]: https://arxiv.org/abs/2406.01234 "LoRA Leakage: Gradient Inversion Attacks"
+[27]: https://arxiv.org/abs/2310.15140 "AutoDAN: Interpretable Gradient-Based Adversarial Attacks on Large Language Models"
+[28]: https://arxiv.org/abs/2505.09921 "PIG: Privacy Jailbreak Attack on LLMs via Gradient-based Iterative In-Context Optimization"

--- a/docs/optimization/autodan-interpretable.md
+++ b/docs/optimization/autodan-interpretable.md
@@ -1,0 +1,8 @@
+---
+title: "AutoDAN: Interpretable Gradient-Based Adversarial Attacks"
+category: "Optimization"
+source_url: "https://arxiv.org/abs/2310.15140"
+date_collected: 2025-06-18
+license: "Fair Use"
+---
+The paper **AutoDAN** introduces an interpretable gradient-based framework for generating jailbreak prompts against large language models. By optimizing perturbations guided by model gradients, AutoDAN produces minimally modified prompts that evade safety filters while preserving semantics. The approach is evaluated in white-box settings and lays groundwork for later automated jailbreak strategies.

--- a/docs/optimization/autodan-stealthy.md
+++ b/docs/optimization/autodan-stealthy.md
@@ -1,0 +1,8 @@
+---
+title: "AutoDAN: Generating Stealthy Jailbreak Prompts on Aligned LLMs"
+category: "Optimization"
+source_url: "https://arxiv.org/abs/2310.04451"
+date_collected: 2025-06-18
+license: "Fair Use"
+---
+This AutoDAN variant focuses on creating stealthy jailbreak prompts that maintain benign appearances. Leveraging gradient feedback, the method iteratively crafts adversarial examples that slip past alignment defenses. The authors demonstrate strong attack success on multiple instruction-tuned models, highlighting the potency of gradient-guided optimization for jailbreaks.

--- a/docs/optimization/pig-jailbreak.md
+++ b/docs/optimization/pig-jailbreak.md
@@ -1,0 +1,8 @@
+---
+title: "PIG: Privacy Jailbreak via Gradient-based In-Context Optimization"
+category: "Optimization"
+source_url: "https://arxiv.org/abs/2505.09921"
+date_collected: 2025-06-18
+license: "Fair Use"
+---
+The 2025 paper **PIG** proposes a privacy-oriented jailbreak attack that iteratively tunes in-context examples using gradient signals. By optimizing the prompt to maximize leaked information, PIG extracts sensitive data from models that would otherwise refuse. The attack works even in black-box settings through gradient estimation.


### PR DESCRIPTION
## Summary
- add AutoDAN resources and PIG attack to optimization folder
- list new gradient-based references in additional resources
- expand gradient-based approaches section in catalog

## Testing
- `python scripts/generate_sbom.py`
- `python scripts/link_check.py` *(failed: domain blocked)*
- `pytest -q` *(failed: KeyboardInterrupt due to link_check)*

------
https://chatgpt.com/codex/tasks/task_e_6853d30066c88320a6dad1078212b102