### PR TITLE
Update README counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A searchable website built with **MkDocs Material** is automatically deployed to
 ## Documentation Timeline
 
 - All documentation files under `docs/` include YAML front matter with a `date_collected` of **2025-06-18**, marking the snapshot used to build the catalog. Later commits refine tooling and link archives, but the documentation content reflects that 2025-06-18 snapshot.
-- The `@extractions1/` directory holds **37** markdown drafts automatically converted on **2025-06-19**. These drafts are queued for future integration into the main catalog.
+- The `@extractions1/` directory holds **39** markdown drafts automatically converted on **2025-06-19**. These drafts are queued for future integration into the main catalog.
 - The repository was initially committed on **2025-06-18**, establishing the baseline snapshot.
 
 ## Repository Structure
@@ -77,9 +77,9 @@ A searchable website built with **MkDocs Material** is automatically deployed to
 
 ## Repository Statistics
 
-- The `docs/` folder contains **19** themed subdirectories with a total of **89** documents (42 Markdown and 47 HTML).
-- `docs_files.txt` lists **70** canonical entries used to build the site.
-- `all_files.txt` inventories **131** tracked files across the repository.
+- The `docs/` folder contains **19** themed subdirectories with a total of **92** documents (45 Markdown and 47 HTML).
+- `docs_files.txt` lists **71** canonical entries used to build the site.
+- `all_files.txt` inventories **132** tracked files across the repository.
 - GitHub Actions run on **Python 3.10** and **Node 18**, while pre‑commit hooks
   pin markdownlint **v0.38.0** and codespell **v2.4.1**.
 - `sbom.json` follows the **CycloneDX&nbsp;1.5** specification for reproducible


### PR DESCRIPTION
## Summary
- fix counts in README for docs, docs_files and all_files
- note that @extractions1 has 39 markdown drafts

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_sbom.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d76103908320978ff8e7b93a109d