### PR TITLE
Add extra prompt engineering references

### DIFF
--- a/docs/additional-resources.md
+++ b/docs/additional-resources.md
@@ -142,3 +142,4 @@ These references track emerging threats and defence research through 2026 and ar
 - [Prompt Injection Resources 2026](prompt-dialogue/prompt-injection-resources-2026.md)
 - [Prompt Engineering Attack Resources 2026](prompt-dialogue/prompt-engineering-resources-2026.md)
 - [Fuzzing Resources 2026](fuzzing/fuzzing-resources-2026.md)
+- [Prompt Engineering Attack Resources Extra](prompt-dialogue/prompt-engineering-resources-extra.md)

--- a/docs/prompt-dialogue/prompt-engineering-resources-extra.md
+++ b/docs/prompt-dialogue/prompt-engineering-resources-extra.md
@@ -1,0 +1,17 @@
+---
+title: "Prompt Engineering Attack Resources Extra"
+category: "Prompt Dialogue"
+source_url: ""
+date_collected: 2025-06-18
+license: "CC-BY-4.0"
+---
+
+The following references expand the catalog with additional credible writings and tools focused on prompt engineering attacks.
+
+- [CyberSecEval 3 – Advancing the Evaluation of Cybersecurity Risks and Capabilities in Large Language Models](https://ai.meta.com/research/publications/cyberseceval-3-advancing-the-evaluation-of-cybersecurity-risks-and-capabilities-in-large-language-models/)
+- [Prompt Guard: Meta's Injection and Jailbreak Filter](https://ai.meta.com/blog/meta-llama-3-1-ai-responsibility/)
+- [Llama Agentic System Reference Implementation](https://github.com/meta-llama/llama-agentic-system)
+- [OpenAI Guide on Mitigating Prompt Injection](https://platform.openai.com/docs/guides/prompt-engineering/prompt-injection)
+- [OpenAI Model Spec – Chain of Command Guidance](https://cdn.openai.com/spec/model-spec-2024-05-08.html)
+
+These sources highlight advanced evaluation frameworks, mitigation tools, and best practice guidance that help defend against prompt engineering threats.


### PR DESCRIPTION
## Summary
- collect more references for prompt engineering attacks
- link new page from additional resources

## Testing
- `FAST_LINK_CHECK=1 pytest -q`
- `pre-commit run --files docs/prompt-dialogue/prompt-engineering-resources-extra.md docs/additional-resources.md` *(failed: `SecurityCompromiseError` cloning from GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_6853dbc0f65483208ff1b1553b1a7d0c