### PR TITLE
Add new Puzzler references

### DIFF
--- a/docs/additional-resources.md
+++ b/docs/additional-resources.md
@@ -135,6 +135,7 @@ These references track emerging threats and defence research through 2026 and ar
 - [Jigsaw Puzzles: Splitting Harmful Questions to Jailbreak Large Language Models](https://arxiv.org/abs/2410.11459)
 - [Jailbreak Attacks and Defenses Against Large Language Models: A Survey](https://arxiv.org/abs/2407.04295)
 - [WordGame: Efficient & Effective LLM Jailbreak via Simultaneous Obfuscation in Query and Response](https://arxiv.org/abs/2405.14023)
+- [BaitAttack: Alleviating Intention Shift in Jailbreak Attacks via Adaptive Bait Crafting](https://aclanthology.org/2024.emnlp-main.877/)
 - [Jailbreaking to Jailbreak](https://arxiv.org/abs/2502.09638)
 - [SequentialBreak: Large Language Models Can be Fooled by Embedding Jailbreak Prompts into Sequential Prompt Chains](https://arxiv.org/abs/2411.06426)
 - [Continuous Embedding Attacks via Clipped Inputs in Jailbreaking Large Language Models](https://arxiv.org/abs/2407.13796)

--- a/docs/prompt-dialogue/puzzler-indirect-jailbreak.md
+++ b/docs/prompt-dialogue/puzzler-indirect-jailbreak.md
@@ -25,5 +25,6 @@ The following papers expand on or cite the Puzzler technique:
 - **BaitAttack: Alleviating Intention Shift in Jailbreak Attacks via Adaptive Bait Crafting** ([ACL Anthology 2024](https://aclanthology.org/2024.emnlp-main.877/)) – discusses indirect jailbreaks and Puzzler in the context of intention-preserving attacks.
 - **Jailbreak Attacks and Defenses Against Large Language Models: A Survey** ([arXiv:2407.04295](https://arxiv.org/abs/2407.04295)) – surveys indirect jailbreak techniques and highlights Puzzler's effectiveness.
 - **SequentialBreak: Large Language Models Can be Fooled by Embedding Jailbreak Prompts into Sequential Prompt Chains** ([arXiv:2411.06426](https://arxiv.org/abs/2411.06426)) – extends Puzzler-style indirect prompts across multiple turns.
+- **AutoJailbreak: Exploring Jailbreak Attacks and Defenses through a Dependency Lens** ([arXiv:2406.03805](https://arxiv.org/abs/2406.03805)) – analyzes large jailbreak datasets and references Puzzler in its taxonomy.
 
 These resources provide deeper context on how clue‑based prompting evolves and how researchers are responding with mitigation strategies.

--- a/index.json
+++ b/index.json
@@ -79,6 +79,13 @@
       "category": "Prompt Dialogue",
       "sub_category": "",
       "date_collected": "2025-06-18"
+    },
+    {
+      "title": "Puzzler Indirect Jailbreak",
+      "path": "prompt-dialogue/puzzler-indirect-jailbreak.md",
+      "category": "Prompt Dialogue",
+      "sub_category": "",
+      "date_collected": "2025-06-18"
     }
   ],
   "Training Alignment": [


### PR DESCRIPTION
## Summary
- update docs/prompt-dialogue section on Puzzler attack with AutoJailbreak citation
- add BaitAttack reference to additional resources
- list the Puzzler page in the catalog index

## Testing
- `pip install -q requests pyyaml`
- `pytest -q` *(fails: tests blocked by missing modules or network)*

------
https://chatgpt.com/codex/tasks/task_e_6853de6f87d08320bdbd1a654f2863ce