### PR TITLE
Add 2027 prompt engineering resources

### DIFF
--- a/docs/additional-resources.md
+++ b/docs/additional-resources.md
@@ -151,5 +151,6 @@ These references track emerging threats and defence research through 2026 and ar
 - [LAGO: Few-shot Crosslingual Embedding Inversion Attacks via Language Similarity-Aware Graph Optimization](https://arxiv.org/abs/2505.16008)
 - [Prompt Injection Resources 2026](prompt-dialogue/prompt-injection-resources-2026.md)
 - [Prompt Engineering Attack Resources 2026](prompt-dialogue/prompt-engineering-resources-2026.md)
+- [Prompt Engineering Attack Resources 2027](prompt-dialogue/prompt-engineering-resources-2027.md)
 - [Fuzzing Resources 2026](fuzzing/fuzzing-resources-2026.md)
 - [Fuzzing Resources 2027](fuzzing/fuzzing-resources-2027.md)

--- a/docs/prompt-dialogue/prompt-engineering-resources-2027.md
+++ b/docs/prompt-dialogue/prompt-engineering-resources-2027.md
@@ -1,0 +1,26 @@
+---
+title: "Prompt Engineering Attack Resources 2027"
+category: "Prompt Dialogue"
+source_url: ""
+date_collected: 2025-06-19
+license: "CC-BY-4.0"
+---
+
+The resources below expand on prompt engineering-based attacks and defenses. They supplement [prompt-engineering-resources-2026.md](prompt-engineering-resources-2026.md).
+
+- [Is Your Prompt Safe? Investigating Prompt Injection Attacks Against Open-Source LLMs](https://arxiv.org/abs/2505.14368)
+- [Goal-Oriented Prompt Attack and Safety Evaluation for LLMs](https://arxiv.org/abs/2309.11830)
+- [System Prompt Extraction Attacks and Defenses in Large Language Models](https://arxiv.org/abs/2505.23817)
+- [SequentialBreak: Large Language Models Can be Fooled by Embedding Jailbreak Prompts into Sequential Prompt Chains](https://arxiv.org/abs/2411.06426)
+- [Bag of Tricks: Benchmarking of Jailbreak Attacks on LLMs](https://arxiv.org/abs/2406.09324)
+- [A Survey of Attacks on Large Language Models](https://arxiv.org/abs/2505.12567)
+- [Leveraging the Context through Multi-Round Interactions for Jailbreaking Attacks](https://arxiv.org/abs/2402.09177)
+- [Is LLM-as-a-Judge Robust? Investigating Universal Adversarial Attacks on Zero-shot LLM Assessment](https://arxiv.org/abs/2402.14016)
+- [CheatAgent: Attacking LLM-Empowered Recommender Systems via LLM Agent](https://arxiv.org/abs/2504.13192)
+- [Jigsaw Puzzles: Splitting Harmful Questions to Jailbreak Large Language Models](https://arxiv.org/abs/2410.11459)
+- [WordGame: Efficient & Effective LLM Jailbreak via Simultaneous Obfuscation in Query and Response](https://arxiv.org/abs/2405.14023)
+- [Jailbreaking to Jailbreak](https://arxiv.org/abs/2502.09638)
+- [Continuous Embedding Attacks via Clipped Inputs in Jailbreaking Large Language Models](https://arxiv.org/abs/2407.13796)
+- [Against All Odds: Overcoming Typology, Script, and Language Confusion in Multilingual Embedding Inversion Attacks](https://arxiv.org/abs/2408.11749)
+- [Playing Language Game with LLMs Leads to Jailbreaking](https://arxiv.org/abs/2411.12762)
+- [Illusions of Relevance: Using Content Injection Attacks to Deceive Retrievers, Rerankers, and LLM Judges](https://arxiv.org/abs/2501.18536)


### PR DESCRIPTION
## Summary
- add `prompt-engineering-resources-2027.md` with new links
- link the new page from the additional resources list

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_link_check.py -q` *(fails: KeyboardInterrupt, likely due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6853dfefa8a483208c95fb9ca2d40edc