### PR TITLE
Add prompt-engineering resources 2028

### DIFF
--- a/docs/additional-resources.md
+++ b/docs/additional-resources.md
@@ -178,6 +178,7 @@ These references track emerging threats and defence research through 2026 and ar
 - [Fuzzing Resources 2026](fuzzing/fuzzing-resources-2026.md)
 - [Prompt Engineering Attack Resources Extra](prompt-dialogue/prompt-engineering-resources-extra.md)
 - [Prompt Engineering Attack Resources 2027](prompt-dialogue/prompt-engineering-resources-2027.md)
+- [Prompt Engineering Attack Resources 2028](prompt-dialogue/prompt-engineering-resources-2028.md)
 - [Additional Resources on LLM Attacks 2027](additional-resources-2027.md)
 - [Fuzzing Resources 2027](fuzzing/fuzzing-resources-2027.md)
 - [Fuzzing Resources 2028](fuzzing/fuzzing-resources-2028.md)

--- a/docs/prompt-dialogue/prompt-engineering-resources-2028.md
+++ b/docs/prompt-dialogue/prompt-engineering-resources-2028.md
@@ -1,0 +1,25 @@
+---
+title: "Prompt Engineering Attack Resources 2028"
+category: "Prompt Dialogue"
+source_url: ""
+date_collected: 2025-06-19
+license: "CC-BY-4.0"
+---
+
+The resources below expand on prompt engineering-based attacks and mitigation approaches. They complement [prompt-engineering-resources-2027.md](prompt-engineering-resources-2027.md).
+
+- [COLD-Attack: Jailbreaking LLMs with Stealthiness and Controllability](http://arxiv.org/abs/2402.08679)
+- [Don't Say No: Jailbreaking LLM by Suppressing Refusal](https://arxiv.org/abs/2404.16369)
+- [Mission Impossible: A Statistical Perspective on Jailbreaking LLMs](http://arxiv.org/abs/2408.01420)
+- [Hacc-Man: An Arcade Game for Jailbreaking LLMs](https://doi.org/10.1145/3656156.3665432)
+- [Bad Likert Judge Jailbreak Technique](https://thehackernews.com/2025/01/new-ai-jailbreak-method-bad-likert.html)
+- [AutoDAN: Interpretable Gradient-Based Adversarial Attacks on Large Language Models](https://arxiv.org/abs/2310.15140)
+- [AutoDAN: Generating Stealthy Jailbreak Prompts on Aligned LLMs](https://arxiv.org/abs/2310.04451)
+- [Effective Prompt Extraction from Language Models](https://arxiv.org/abs/2307.06865)
+- [ASETF: A Novel Method for Jailbreak Attack on LLMs through Translate Suffix Embeddings](https://arxiv.org/abs/2402.16006)
+- [Prompt Injection Attack Research](https://arxiv.org/abs/2410.13236)
+- [SPIN: Self-Supervised Prompt Injection](https://www.researchgate.net/publication/385010187_SPIN_Self-Supervised_Prompt_Injection)
+- [Fine-Tuning LLMs to Resist Indirect Prompt Injection](https://labs.reversec.com/posts/2024/10/fine-tuning-llms-to-resist-indirect-prompt-injection-attacks)
+- [Lakera PINT Benchmark](https://github.com/lakeraai/pint-benchmark)
+- [Prompt Injection Datasets on HuggingFace](https://huggingface.co/datasets/deepset/prompt-injections)
+- [Prompt Injection Cheat Sheet Documentation](https://prompt-injections.readthedocs.io/en/latest/dataset.html)


### PR DESCRIPTION
## Summary
- add new prompt engineering references for 2028
- link the new file in additional-resources

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError and networking issues)*

------
https://chatgpt.com/codex/tasks/task_e_6853fcc4fe4483208bb688eb1f44291e