### PR TITLE
Add neuron-level attack resources

### DIFF
--- a/docs/neuron-resources-2027.md
+++ b/docs/neuron-resources-2027.md
@@ -1,0 +1,20 @@
+---
+title: "Neuron-Level Manipulation Resources 2027"
+category: "Latent Space"
+source_url: ""
+date_collected: 2025-06-19
+license: "CC-BY-4.0"
+---
+
+The references below supplement [neuron-resources.md](neuron-resources.md) with additional research and articles published after the original snapshot. They explore advanced neuron-level editing and analysis techniques for large language models.
+
+## Research Papers
+
+- [MMNeuron: Discovering Neuron-Level Domain-Specific Interpretation in Multimodal Large Language Model](https://doi.org/10.18653/v1/2024.emnlp-main.387) – analyses how individual neurons capture domain-specific features.
+- [Neuron-Level Knowledge Attribution in Large Language Models](https://doi.org/10.18653/v1/2024.emnlp-main.191) – proposes static attribution methods to identify influential neurons.
+- [Automated Neuron Explanation for Code-Trained Language Models](https://doi.org/10.31274/cc-20240624-267) – introduces a system for mapping code semantics to specific neuron activations.
+- [Locate-then-Merge: Neuron-Level Parameter Fusion for Mitigating Catastrophic Forgetting in Multimodal LLMs](https://arxiv.org/abs/2505.16703) – merges neurons from specialized models to preserve skills.
+- [Let's Focus on Neuron: Neuron-Level Supervised Fine-tuning for Large Language Model](https://arxiv.org/abs/2403.11621) – fine-tunes individual neurons to improve specific tasks.
+- [Unveiling Language Competence Neurons: A Psycholinguistic Approach to Model Interpretability](https://arxiv.org/abs/2409.15827) – uses psycholinguistic experiments to inspect neuron-level capabilities.
+- [Towards Understanding Multi-Task Learning of LLMs via Detecting and Exploring Task-Specific Neurons](https://arxiv.org/abs/2407.06488) – correlates neuron overlap with generalization across tasks.
+- [Editing Memories Through Few Targeted Neurons](https://ojs.aaai.org/index.php/AAAI/article/view/34807) – demonstrates how modifying a small set of neurons can alter language model behaviour.


### PR DESCRIPTION
## Summary
- add new neuron manipulation references for 2027

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6853fe1c67c483209efb3f0b0405b0fc