### PR TITLE
Add authority simulation resources 2027

### DIFF
--- a/docs/additional-resources.md
+++ b/docs/additional-resources.md
@@ -174,4 +174,5 @@ These references track emerging threats and defence research through 2026 and ar
 - [Additional Resources on LLM Attacks 2027](additional-resources-2027.md)
 - [Fuzzing Resources 2027](fuzzing/fuzzing-resources-2027.md)
 - [Authority Simulation Attack Resources 2026](social-engineering/authority-simulation-resources-2026.md)
+- [Authority Simulation Attack Resources 2027](social-engineering/authority-simulation-resources-2027.md)
 - [Social Engineering and Emotional Manipulation Resources](social-engineering/emotional-manipulation-resources.md)

--- a/docs/social-engineering/authority-simulation-resources-2027.md
+++ b/docs/social-engineering/authority-simulation-resources-2027.md
@@ -1,0 +1,24 @@
+---
+title: "Authority Simulation Attack Resources 2027"
+category: "Social Engineering"
+source_url: ""
+date_collected: 2025-06-19
+license: "CC-BY-4.0"
+---
+
+The resources below expand on authority-based impersonation and social-engineering techniques for large language model attacks. They supplement [authority-simulation-resources-2026.md](authority-simulation-resources-2026.md).
+
+- [The Dark Side of Trust: Authority Citation-Driven Jailbreak Attacks on Large Language Models](https://arxiv.org/abs/2411.11407)
+- [Defending Against Social Engineering Attacks in the Age of LLMs](https://aclanthology.org/2024.emnlp-main.716)
+- [Temporal Context Awareness: A Defense Framework Against Multi-turn Social Engineering Attacks](https://arxiv.org/abs/2503.15560)
+- [Personalized Attacks of Social Engineering in Multi-turn Conversations -- LLM Agents for Simulation and Detection](https://arxiv.org/abs/2503.15552)
+- [LLM Agent Honeypot: Real-World AI Threat Analysis](https://ai-honeypot.palisaderesearch.org/)
+- [AI-Powered Social Engineering and Impersonation Attacks](https://www.igi-global.com/chapter/ai-powered-social-engineering-and-impersonation-attacks/378281)
+- [Impersonation - Security Through Education](https://www.social-engineer.org/framework/attack-vectors/impersonation/)
+- [Social Engineering: Traditional Tactics and the Emerging Role of AI](https://www.lakera.ai/blog/social-engineering)
+- [How does impersonation work in social engineering?](https://www.cyberly.org/en/how-does-impersonation-work-in-social-engineering/index.html)
+- [Social engineering in the era of generative AI: Predictions for 2024](https://www.ibm.com/think/insights/social-engineering-generative-ai-2024-predictions)
+- [Weaponizing Social Intelligence](https://ieeexplore.ieee.org/document/10666472)
+- [Large Language Models and Security](https://ieeexplore.ieee.org/document/10413528)
+- [Exploiting Large Language Models through Deception Techniques and Persuasion Principles](https://montrealethics.ai/exploiting-large-language-models-llms-through-deception-techniques-and-persuasion-principles/)
+- [Practical Attacks on LLMs: Full Guide](https://iterasec.com/blog/practical-attacks-on-llms/)


### PR DESCRIPTION
## Summary
- add new 2027 authority simulation resource list under `docs/social-engineering`
- link the new resource list from `additional-resources.md`

## Testing
- `pre-commit run --files docs/additional-resources.md docs/social-engineering/authority-simulation-resources-2027.md` *(failed: could not install pre-commit hooks due to network restrictions)*
- `pytest -q` *(failed: tests did not run before interruption)*

------
https://chatgpt.com/codex/tasks/task_e_6853f76f2b548320a7f82545991f6572