### PR TITLE
Add more token-level attack references

### DIFF
--- a/docs/token-level/additional-token-level-resources.md
+++ b/docs/token-level/additional-token-level-resources.md
@@ -34,3 +34,15 @@ The following references provide further background on tokenization-based attack
 - [Some Notes on Adversarial Attacks on LLMs](https://cybernetist.com/2024/09/23/some-notes-on-adversarial-attacks-on-llms/) - Practitioner notes covering token-level manipulations.
 - [Beware of Special Token Injections in LLMs](https://medium.com/@_jeremy_/beware-of-special-token-injections-in-llms-a-new-form-of-sql-injection-like-attack-d0bceb8bda94) - Medium article describing reserved-token injection risks.
 - [The Subtle Art of Jailbreaking LLMs](https://andpalmier.com/posts/jailbreaking-llms/) - High-level guide to jailbreak strategies including token-focused tricks.
+- [Novel TokenBreak Attack Method Can Bypass LLM Security Features](https://securityboulevard.com/2025/06/novel-tokenbreak-attack-method-can-bypass-llm-security-features/) - Security Boulevard's analysis of a TokenBreak variant.
+- [TokenBreak Attack - Single Character Bypass Defeats LLM Safety](https://www.cyberkendra.com/2025/06/tokenbreak-attack-single-character.html) - Explanation of the single-character trick.
+- [Simple Typo Breaks AI Safety Via TokenBreak](https://cybermaterial.com/simple-typo-breaks-ai-safety-via-tokenbreak/) - Demonstration of the bypass in practice.
+- [TokenBreak Exploit Tricks AI Models Using Minimal Input Changes](https://gbhackers.com/tokenbreak-exploit-tricks-ai-models/) - Step-by-step demonstration of the exploit.
+- [TokenBreak Attack Bypasses AI Models with a Single Character](https://cyberpress.org/tokenbreak-attack-bypasses-ai-models/) - Security blog summary of the weakness.
+- [TokenBreak Attack Bypasses LLM Protective Guardrails](https://www.spartechsoftware.com/cybersecurity-news/new-tokenbreak-attack-bypasses-llm-protective-guardrails/) - Coverage of defensive shortcomings.
+- [Emoji Jailbreaks: Are Your AI Models Vulnerable?](https://medium.com/google-cloud/emoji-jailbreaks-b3b5b295f38b) - Google Cloud article on emoji-based bypasses.
+- [Hackers Can Bypass Microsoft, Nvidia, & Meta AI Filters With a Simple Emoji](https://cybersecuritynews.com/hackers-can-bypass-microsoft-nvidia-meta-ai-filters/) - News report on real-world emoji attacks.
+- [AI Guardrail Vulnerability Exposed: How Emoji Smuggling Bypasses LLM Safety Filters](https://windowsforum.com/threads/ai-guardrail-vulnerability-exposed-how-emoji-smuggling-bypasses-llm-safety-filters.365061/) - Discussion of smuggling vulnerabilities.
+- [Understanding Emoji AI Hacking: How Unicode Threatens AI](https://www.geeky-gadgets.com/emoji-exploits-in-ai-security/) - Technical overview of emoji exploits.
+- [The Emoji Attack: A New Threat Vector in AI Safety Evaluation](https://medium.com/@bhargavaganti/the-emoji-attack-a-new-threat-vector-in-ai-safety-evaluation-6ab07ff4f107) - Analysis of emoji sequences in jailbreaks.
+- [The Hidden Dangers of Adversarial Tokenization](https://medium.com/data-science-collective/the-hidden-dangers-of-adversarial-tokenization-how-token-splitting-bypasses-ai-safeguards-4e3b651f6a22) - In-depth look at token-splitting risks.

--- a/docs/token-level/token-prediction-resources.md
+++ b/docs/token-level/token-prediction-resources.md
@@ -13,3 +13,9 @@ These papers and articles explore how adversaries abuse next-token prediction or
 - [Obfuscation/Token Smuggling - Learn Prompting](https://learnprompting.org/docs/prompt_hacking/offensive_measures/obfuscation)
 - [Token-Smuggling: The Hidden Threat to A.I. and GPT Models](https://hashdork.com/token-smuggling/)
 - [Mitigating a Token-Length Side-Channel Attack in Our AI Products](https://blog.cloudflare.com/ai-side-channel-attack-mitigated/)
+- [What Was Your Prompt? A Remote Keylogging Attack on AI Assistants](https://arxiv.org/abs/2403.09751) - Describes a side-channel attack recovering prompts via token predictions.
+- [Hackers Can Read Private AI-Assistant Chats Despite Encryption](https://arstechnica.com/security/2024/03/hackers-can-read-private-ai-assistant-chats-even-though-theyre-encrypted/) - ArsTechnica article on token-length side channels.
+- [ChatGPT and Microsoft Copilot Chats Vulnerable to Token-Length Side-Channel Attack](https://veruscorp.com/chatgpt-and-microsoft-copilot-chats-vulnerable-to-token-length-side-channel-attack/) - Blog detailing the vulnerability.
+- [ChatGPT Side-Channel Attack Has Easy Fix: Token Obfuscation](https://www.theregister.com/2024/03/18/chatgpt_sidechannel_attack_has_easy/) - The Register coverage proposing defences.
+- [AI Conversations Exposed: The Token Length Vulnerability](https://medium.com/@firefalc0n/ai-conversations-exposed-the-token-length-vulnerability-in-chatgpt-copilot-and-more-0d182973c1ee) - Medium article exploring token-length leakage.
+- [Awesome Side Channels](https://github.com/dpaleka/awesome-side-channels) - Curated list of research on side-channel attacks including token-based exploits.


### PR DESCRIPTION
## Summary
- expand token-level attack bibliography with new sources
- include recent articles on token prediction side channels

## Testing
- `pre-commit run --files docs/token-level/additional-token-level-resources.md docs/token-level/token-prediction-resources.md` *(fails: Username for 'https://github.com')*
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6853f7b43f648320bfd71b53fc84e0ad