### PR TITLE
Add authority simulation references

### DIFF
--- a/docs/additional-resources.md
+++ b/docs/additional-resources.md
@@ -206,4 +206,5 @@ These references track emerging threats and defence research through 2026 and ar
 - [Fuzzing Resources 2030](fuzzing/fuzzing-resources-2030.md)
 - [Authority Simulation Attack Resources 2026](social-engineering/authority-simulation-resources-2026.md)
 - [Authority Simulation Attack Resources 2027](social-engineering/authority-simulation-resources-2027.md)
+- [Authority Simulation Attack Resources 2028](social-engineering/authority-simulation-resources-2028.md)
 - [Social Engineering and Emotional Manipulation Resources](social-engineering/emotional-manipulation-resources.md)

--- a/docs/social-engineering/authority-simulation-resources-2028.md
+++ b/docs/social-engineering/authority-simulation-resources-2028.md
@@ -1,0 +1,20 @@
+---
+title: "Authority Simulation Attack Resources 2028"
+category: "Social Engineering"
+source_url: ""
+date_collected: 2025-06-20
+license: "CC-BY-4.0"
+---
+
+Below are additional authoritative resources on social-engineering attacks that impersonate trusted figures or cite false authority to bypass LLM safeguards. They extend [authority-simulation-resources-2027.md](authority-simulation-resources-2027.md).
+
+- [Authority Citation Jailbreak \| LLM Security Database](https://www.promptfoo.dev/lm-security-db/vuln/undefined-85d41cb4)
+- [The Dark Side of Citation: How LLMs Get Tricked](https://www.promptlayer.com/research-papers/the-dark-side-of-citation-how-llms-get-tricked)
+- [Intention Analysis Makes LLMs A Good Jailbreak Defender](https://aclanthology.org/2025.coling-main.199/)
+- [How Alignment and Jailbreak Work: Explain LLM Safety through Real Scenarios](https://aclanthology.org/2024.findings-emnlp.139/)
+- [JailGuard: A Universal Detection Framework for Prompt-based Attacks on Language Models](https://dl.acm.org/doi/10.1145/3724393)
+- [When LLMs Go Online: The Emerging Threat of Web-Enabled LLMs](https://arxiv.org/abs/2410.14569)
+- [Strategies to Detect and Prevent LLM Security Challenges](https://medium.com/thesecmaster/5-security-challenges-in-llms-and-strategies-to-prevent-them-9279f8d7eaf5)
+- [Exploring Attacks on Large Language Models: From Prompt Injection to Jailbreaking](https://medium.com/@pouyahallaj/exploring-attacks-on-large-language-models-llms-from-prompt-injection-to-jailbreaking-and-beyond-9e51bdd3cc9b)
+- [5 Types of Impersonation Attacks and 6 Ways to Prevent Them](https://perception-point.io/guides/phishing/5-types-of-impersonation-attacks-and-6-ways-to-prevent-them/)
+- [Preventing Impersonation Fraud with Semantic Analysis](https://www.proofpoint.com/us/blog/email-and-cloud-threats/preventing-impersonation-fraud-semantic-analysis-llm)


### PR DESCRIPTION
## Summary
- add 2028 authority-simulation resources
- link new file from additional resources

## Testing
- `pre-commit run --files docs/social-engineering/authority-simulation-resources-2028.md docs/additional-resources.md` *(fails: requesting GitHub credentials)*
- `pytest -q` *(fails: network restrictions prevented test completion)*

------
https://chatgpt.com/codex/tasks/task_e_68540422e3188320a0af38bd008817e3