### PR TITLE
Add gradient-based attack resources

### DIFF
--- a/docs/navigation-map.md
+++ b/docs/navigation-map.md
@@ -111,6 +111,10 @@ Primary source articles grouped by theme. Markdown files include YAML front matt
 - `gradient-based-adversarial-transformers.md` — adversarial distribution search
 - `gradient-based-attack-resources.md` — curated references on gradient-guided attacks
 - `gradient-resources-2026.md` — additional gradient-based jailbreak research
+- `boosting-jailbreak-with-momentum.md` — momentum-based gradient attack
+- `dager-gradient-inversion.md` — exact gradient inversion method
+- `improved-techniques-for-jailbreaking.md` — refined optimization approach
+- `llm-abuse-prevention-gcg.md` — GCG jailbreak detection with DistilBERT
 
 ### prompt-dialogue/
 - `gpt4v-safe.html` — safe multimodal prompt

--- a/docs/optimization/boosting-jailbreak-with-momentum.md
+++ b/docs/optimization/boosting-jailbreak-with-momentum.md
@@ -1,0 +1,9 @@
+---
+title: "Boosting Jailbreak Attack with Momentum"
+category: "Optimization"
+source_url: "https://doi.org/10.1109/icassp49660.2025.10888812"
+date_collected: 2025-06-18
+license: "Fair Use"
+---
+This IEEE paper introduces a momentum-based variant of gradient jailbreak attacks.
+By accumulating gradient history, the method discovers adversarial suffixes faster than vanilla GCG and improves transferability across models.

--- a/docs/optimization/dager-gradient-inversion.md
+++ b/docs/optimization/dager-gradient-inversion.md
@@ -1,0 +1,9 @@
+---
+title: "DAGER: Exact Gradient Inversion"
+category: "Optimization"
+source_url: "https://arxiv.org/abs/2405.15586"
+date_collected: 2025-06-18
+license: "Fair Use"
+---
+**DAGER** demonstrates an exact gradient inversion technique capable of reconstructing training data from gradient queries on large language models.
+The approach poses serious privacy risks during fine-tuning or alignment, recovering prompts and model parameters with high fidelity.

--- a/docs/optimization/gradient-based-attack-resources.md
+++ b/docs/optimization/gradient-based-attack-resources.md
@@ -27,3 +27,8 @@ This list collects notable research papers, blog posts and repositories that dev
 - [AutoPrompt: Eliciting Knowledge from Language Models with Automatically Generated Prompts](https://arxiv.org/abs/2010.15980)
 - [Gradient Hacking in Reinforcement Learning](https://arxiv.org/abs/2106.09685)
 - [Gradient Leakage and Model Inversion via LoRA](https://arxiv.org/abs/2406.01234)
+- [Boosting Jailbreak Attack with Momentum](https://doi.org/10.1109/icassp49660.2025.10888812)
+- [Improved Techniques for Optimization-Based Jailbreaking on Large Language Models](https://arxiv.org/abs/2405.21018)
+- [DAGER: Exact Gradient Inversion for Large Language Models](https://arxiv.org/abs/2405.15586)
+- [LLM Abuse Prevention Tool Using GCG Jailbreak Attack Detection and DistilBERT-Based Ethics Judgment](https://doi.org/10.3390/info16030204)
+- [Gradient-Based Privacy Jailbreak | LLM Security Database](https://www.promptfoo.dev/lm-security-db/vuln/undefined-0282d4f5)

--- a/docs/optimization/improved-techniques-for-jailbreaking.md
+++ b/docs/optimization/improved-techniques-for-jailbreaking.md
@@ -1,0 +1,9 @@
+---
+title: "Improved Techniques for Optimization-Based Jailbreaking"
+category: "Optimization"
+source_url: "https://arxiv.org/abs/2405.21018"
+date_collected: 2025-06-18
+license: "Fair Use"
+---
+The 2024 paper **Improved Techniques for Optimization-Based Jailbreaking on Large Language Models** refines gradient-driven attacks like GCG.
+Key contributions include adaptive learning schedules and momentum terms that accelerate convergence to high-success prompts. The authors demonstrate superior success rates on aligned models compared to earlier methods.

--- a/docs/optimization/llm-abuse-prevention-gcg.md
+++ b/docs/optimization/llm-abuse-prevention-gcg.md
@@ -1,0 +1,9 @@
+---
+title: "LLM Abuse Prevention via GCG Jailbreak Detection"
+category: "Optimization"
+source_url: "https://doi.org/10.3390/info16030204"
+date_collected: 2025-06-18
+license: "CC-BY-4.0"
+---
+This 2024 study proposes an automated tool to detect and filter gradient-based jailbreak attempts.
+It relies on GCG-generated samples to train a DistilBERT classifier, achieving high accuracy in spotting malicious prompts before they succeed.


### PR DESCRIPTION
## Summary
- catalog improved gradient-based jailbreaking research
- add new docs for momentum-based attacks, gradient inversion, mitigation, and optimization
- update navigation map and references list

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_sbom.py -q`
- `pytest tests/test_link_check.py -q` *(fails: KeyboardInterrupt due to blocked domain)*

------
https://chatgpt.com/codex/tasks/task_e_6854040f55e4832083b58e7b41174c93