### PR TITLE
Add 2030 prompt engineering resources

### DIFF
--- a/docs/prompt-dialogue/prompt-engineering-resources-2030.md
+++ b/docs/prompt-dialogue/prompt-engineering-resources-2030.md
@@ -1,0 +1,30 @@
+---
+title: "Prompt Engineering Attack Resources 2030"
+category: "Prompt Dialogue"
+source_url: ""
+date_collected: 2025-06-19
+license: "CC-BY-4.0"
+---
+
+The references below extend the prompt engineering attack catalog with recent research papers and articles. They complement [prompt-engineering-resources-2029.md](prompt-engineering-resources-2029.md).
+
+- [Mind Mapping Prompt Injection: Visual Prompt Injection Attacks in Modern Large Language Models](https://doi.org/10.3390/electronics14101907)
+- [Goal-Guided Generative Prompt Injection Attack on Large Language Models](https://doi.org/10.1109/icdm59182.2024.00119)
+- [Text-Based Prompt Injection Attack Using Mathematical Functions in Modern Large Language Models](https://doi.org/10.3390/electronics13245008)
+- [Attack on Prompt: Backdoor Attack in Prompt-Based Continual Learning](https://doi.org/10.1609/aaai.v39i18.34168)
+- [TAPDA: Text Adversarial Purification as Defense Against Adversarial Prompt Attack for Large Language Models](https://doi.org/10.1109/icaace65325.2025.11020575)
+- [Multilingual Prompt Injection Attacks Detection: Evaluating Adversarial Robustness in Large Language Models](https://doi.org/10.2139/ssrn.5244151)
+- [Privacy-Preserving Prompt Injection Detection for Smart Cloud-Deployed Large Language Models](https://doi.org/10.1109/smartcloud66068.2025.00009)
+- [MalPID: Malicious Prompt Injection Detection Dataset for Large Language Model based Applications](https://doi.org/10.1109/comnet64071.2024.10987374)
+- [SoK: Prompt Hacking of Large Language Models](https://doi.org/10.1109/bigdata62323.2024.10825103)
+- [Prompt Crossing: Evaluating Whether LLM Response Stem from Jailbreak or Normal Prompt](https://doi.org/10.1109/icassp49660.2025.10889949)
+- [RePD: Defending Jailbreak Attack through a Retrieval-based Prompt Decomposition Process](https://doi.org/10.18653/v1/2025.findings-naacl.16)
+- [Mitigating Adversarial Manipulation in LLMs: A Prompt-Based Approach to Counter Jailbreak Attacks (Prompt-G)](https://doi.org/10.7717/peerj-cs.2374)
+- [Optimizing Transformer Models for Prompt Jailbreak Attack Detection in AI Assistant Systems](https://doi.org/10.1109/vcris63677.2024.10813380)
+- [Adversarial Prompting: How Prompt Engineering Can Be Used to Jailbreak AI](https://doi.org/10.22214/ijraset.2025.70107)
+- [Taxonomy of Prompt Injections (NIST AI 100-2AE2024)](https://doi.org/10.6028/nist.ai.100-2ae2024)
+- [Evaluating Prompt Injection Safety in Large Language Models Using the PromptBench Dataset](https://doi.org/10.31219/osf.io/7zck8)
+- [Secure Artificial Intelligence (SAI): A Dual-layer Defence Model against Prompt Injection and Prompt Poisoning Attacks](https://doi.org/10.36948/ijfmr.2025.v07i01.35371)
+- [Defending ChatGPT against Jailbreak Attack via Self-Reminder](https://doi.org/10.21203/rs.3.rs-2873090/v1)
+
+These sources highlight emerging prompt engineering threats and novel defence strategies heading into 2030.

--- a/docs_files.txt
+++ b/docs_files.txt
@@ -87,3 +87,5 @@ docs/function-calling/function-calling-exploit-resources.md
 docs/latent-space/attention-hijacking-resources.md
 docs/optimization/evolutionary-algorithm-attacks.md
 docs/prompt-dialogue/prompt-engineering-resources-2028.md
+docs/prompt-dialogue/prompt-engineering-resources-2029.md
+docs/prompt-dialogue/prompt-engineering-resources-2030.md

--- a/index.json
+++ b/index.json
@@ -172,6 +172,27 @@
       "date_collected": "2025-06-18"
     },
     {
+      "title": "Prompt Engineering Attack Resources 2028",
+      "path": "prompt-dialogue/prompt-engineering-resources-2028.md",
+      "category": "Prompt Dialogue",
+      "sub_category": "",
+      "date_collected": "2025-06-19"
+    },
+    {
+      "title": "Prompt Engineering Attack Resources 2029",
+      "path": "prompt-dialogue/prompt-engineering-resources-2029.md",
+      "category": "Prompt Dialogue",
+      "sub_category": "",
+      "date_collected": "2025-06-19"
+    },
+    {
+      "title": "Prompt Engineering Attack Resources 2030",
+      "path": "prompt-dialogue/prompt-engineering-resources-2030.md",
+      "category": "Prompt Dialogue",
+      "sub_category": "",
+      "date_collected": "2025-06-19"
+    },
+    {
       "title": "Many-Shot Jailbreaking Resources",
       "path": "prompt-dialogue/many-shot-jailbreaking-resources.md",
       "category": "Prompt Dialogue",


### PR DESCRIPTION
## Summary
- add a new `prompt-engineering-resources-2030.md` page with references to recent prompt engineering attack papers
- update `index.json` so the new page is linked in the Prompt Dialogue section
- list the new page in `docs_files.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: requests, yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68543572230883208de6200ae52299e1