### PR TITLE
Add new gradient-based resources for 2028

### DIFF
--- a/docs/navigation-map.md
+++ b/docs/navigation-map.md
@@ -115,6 +115,7 @@ Primary source articles grouped by theme. Markdown files include YAML front matt
 - `gradient-based-attack-resources.md` — curated references on gradient-guided attacks
 - `gradient-resources-2026.md` — additional gradient-based jailbreak research
 - `gradient-resources-2027.md` — further gradient-based jailbreak references
+- `gradient-resources-2028.md` — latest gradient-based jailbreak studies
 - `evolutionary-algorithm-attacks.md` — overview of GA-based jailbreak techniques
 - `boosting-jailbreak-with-momentum.md` — momentum-based gradient attack
 - `dager-gradient-inversion.md` — exact gradient inversion method

--- a/docs/optimization/gradient-resources-2028.md
+++ b/docs/optimization/gradient-resources-2028.md
@@ -1,0 +1,15 @@
+---
+title: "Gradient Attack Resources 2028"
+category: "Optimization"
+source_url: ""
+date_collected: 2025-06-19
+license: "CC-BY-4.0"
+---
+
+The papers and articles below continue the survey of gradient-based jailbreak techniques and defences published after the 2027 list.
+
+- [Adversarial Attack on Large Language Models using Exponentiated Gradient Descent](https://arxiv.org/abs/2505.09820) – describes an exponentiated gradient descent method to generate high-success adversarial prompts.
+- [DualBreach: Efficient Dual-Jailbreaking via Target-Driven Initialization and Multi-Target Optimization](https://arxiv.org/abs/2504.18564) – optimizes approximate gradients against both guardrails and base models to save queries.
+- [From Hallucinations to Jailbreaks: Rethinking the Vulnerability of Large Foundation Models](https://arxiv.org/abs/2505.24232) – proposes a unified gradient-based view of token-level and attention-level vulnerabilities.
+- [Model Unlearning via Sparse Autoencoder Subspace Guided Projections](https://arxiv.org/abs/2505.24428) – leverages gradient-driven unlearning to reduce malicious accuracy under jailbreak prompts.
+- [Safety Alignment via Constrained Knowledge Unlearning](https://arxiv.org/abs/2505.18588) – prunes sensitive neuron gradients to maintain safety while preserving utility.


### PR DESCRIPTION
## Summary
- add `gradient-resources-2028.md` with recent gradient attack references
- update navigation map to link the new page

## Testing
- `FAST_LINK_CHECK=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685435c48ff08320a6054bbcf6717369