### PR TITLE
Add neuron resources 2028

### DIFF
--- a/all_files.txt
+++ b/all_files.txt
@@ -132,3 +132,6 @@
 ./LICENSE
 ./.pre-commit-config.yaml
 ./docs_files.txt
+./docs/neuron-resources-2028.md
+./docs/neuron-resources.md
+./docs/neuron-resources-2027.md

--- a/docs/navigation-map.md
+++ b/docs/navigation-map.md
@@ -81,6 +81,9 @@ Primary source articles grouped by theme. Markdown files include YAML front matt
 - `latent-space-resources-2026.md` — additional latent-space papers
 - `latent-space-resources-2027.md` — newer latent-space research
 - `latent-space-resources-2028.md` — latest latent-space papers
+- `neuron-resources.md` — neuron-level manipulation references
+- `neuron-resources-2027.md` — updated neuron-focused papers
+- `neuron-resources-2028.md` — recent work on neuron-level attacks
 - `apexhq-latentspace.html` — attack on latent representations
 - `obfuscated-activations.html` — obfuscating activations during alignment
 

--- a/docs/neuron-resources-2028.md
+++ b/docs/neuron-resources-2028.md
@@ -1,0 +1,22 @@
+---
+title: "Neuron-Level Manipulation Resources 2028"
+category: "Latent Space"
+source_url: ""
+date_collected: 2025-06-19
+license: "CC-BY-4.0"
+---
+
+The references below extend the neuron-focused bibliography with new research and tools published after the 2027 update. They highlight emerging work on neuron-level attacks, defenses, and analysis methods for LLMs.
+
+## Research Papers
+
+- [Stealthy Backdoor Attack against Federated Learning through Frequency Domain by Backdoor Neuron Constraint and Model Camouflage](https://doi.org/10.1109/jetcas.2024.3450527) – shows how enforcing neuron constraints enables stealthy backdoors in distributed settings.
+- [Imperio: Language-Guided Backdoor Attacks for Arbitrary Model Control](https://doi.org/10.24963/ijcai.2024/78) – introduces neuron-aligned triggers that let attackers reprogram LLM behaviour.
+- [LLMbd: Backdoor Defense Via Large Language Model Paraphrasing and Data Voting in NLP](https://doi.org/10.2139/ssrn.5131766) – proposes a defense that patches suspect neurons through paraphrased data augmentation.
+- [Causal Analysis of Syntactic Agreement Neurons in Multilingual Language Models](https://doi.org/10.18653/v1/2022.conll-1.8) – analyzes syntactic neurons to reveal cross-language vulnerabilities.
+- [Selective Error Correction for Activation in Large Language Model Training](https://doi.org/10.1109/icce63647.2025.10930198) – corrects faulty activations to resist neuron-level corruption.
+
+## Articles and Links
+
+- [Better Patching Using LLM Prompting, via Self-Consistency](https://doi.org/10.1109/ase56229.2023.00065) – explores automated neuron patching guided by LLM-generated prompts.
+

--- a/docs_files.txt
+++ b/docs_files.txt
@@ -85,3 +85,6 @@ docs/token-level/token-level-resources-2027.md
 docs/streaming/streaming-response-hijacking-resources.md
 docs/function-calling/function-calling-exploit-resources.md
 docs/latent-space/attention-hijacking-resources.md
+docs/neuron-resources.md
+docs/neuron-resources-2027.md
+docs/neuron-resources-2028.md


### PR DESCRIPTION
## Summary
- add 2028 neuron-manipulation resources
- update navigation map
- update docs and file manifests

## Testing
- `pre-commit run --files docs/neuron-resources-2028.md docs/navigation-map.md docs_files.txt all_files.txt` *(fails: Username for 'https://github.com')*
- `pytest -q` *(fails: Username prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6854349543e883209a06a1ed87ed32a3