### PR TITLE
Add 2028 token-level resources

### DIFF
--- a/docs/navigation-map.md
+++ b/docs/navigation-map.md
@@ -158,6 +158,7 @@ Primary source articles grouped by theme. Markdown files include YAML front matt
 - `token-prediction-resources.md` — references on token prediction and side channels
 - `additional-token-level-resources.md` — broader tokenization attack bibliography
 - `token-level-resources-2027.md` — newer token-level manipulation papers
+- `token-level-resources-2028.md` — latest open source tools on hidden tokens
 
 ### training-alignment/
 - `index.md` — overview of training-phase attacks

--- a/docs/token-level/token-level-resources-2028.md
+++ b/docs/token-level/token-level-resources-2028.md
@@ -1,0 +1,15 @@
+---
+title: "Token-Level Attack Resources 2028"
+category: "Tokenization"
+source_url: ""
+date_collected: 2025-06-19
+license: "CC-BY-4.0"
+---
+
+The following references extend the catalog with additional work on token-level manipulation. These resources highlight emerging tools that detect or exploit hidden tokens in LLM prompts.
+
+- [Vibecondom: Detect Hidden Characters](https://github.com/ngmisl/vibe-condom) - Scans for zero-width characters and malicious prompt injections.
+- [Spectre Steganography System](https://github.com/SolsticeMoon/Spectre_Steganography_System) - Proof-of-concept steganography using invisible tokens.
+- [Defend-Token](https://github.com/Lysodium/defend-token) - Repository exploring defences against adversarial token manipulation.
+- [PocoGCG](https://github.com/YancyKahn/PocoGCG) - Research project combining token suppression and induction for jailbreaks.
+


### PR DESCRIPTION
## Summary
- document additional token-level attacks with new GitHub resources
- update navigation map

## Testing
- `FAST_LINK_CHECK=1 python scripts/link_check.py`
- `python scripts/generate_sbom.py`
- `FAST_LINK_CHECK=1 pytest -q` *(fails: broken link)*

------
https://chatgpt.com/codex/tasks/task_e_6854374297108320933d20c7276a8746