### PR TITLE
Add gradient attack resources for 2028

### DIFF
--- a/docs/navigation-map.md
+++ b/docs/navigation-map.md
@@ -115,6 +115,7 @@ Primary source articles grouped by theme. Markdown files include YAML front matt
 - `gradient-based-attack-resources.md` — curated references on gradient-guided attacks
 - `gradient-resources-2026.md` — additional gradient-based jailbreak research
 - `gradient-resources-2027.md` — further gradient-based jailbreak references
+- `gradient-resources-2028.md` — new gradient inversion papers and surveys
 - `evolutionary-algorithm-attacks.md` — overview of GA-based jailbreak techniques
 - `boosting-jailbreak-with-momentum.md` — momentum-based gradient attack
 - `dager-gradient-inversion.md` — exact gradient inversion method

--- a/docs/optimization/gradient-resources-2028.md
+++ b/docs/optimization/gradient-resources-2028.md
@@ -1,0 +1,15 @@
+---
+title: "Gradient Attack Resources 2028"
+category: "Optimization"
+source_url: ""
+date_collected: 2025-06-19
+license: "CC-BY-4.0"
+---
+
+The references below extend the catalog with gradient-based inversion and optimization research beyond the 2027 snapshot.
+
+- [Learning To Invert: Simple Adaptive Attacks for Gradient Inversion in Federated Learning](https://proceedings.mlr.press/v216/wu23a/wu23a.pdf) – presents adaptive gradient inversion techniques that recover training data in federated settings.
+- [Geminio: Language-Guided Gradient Inversion Attacks in Federated Learning](https://arxiv.org/abs/2411.14937) – introduces language-driven gradient inversion that exposes private text.
+- [Gradient Inversion Attack in Federated Learning: Exposing Text Data through Discrete Optimization](https://aclanthology.org/2025.coling-main.176/) – recovers textual training samples via discrete gradient optimization.
+- [A Survey on Gradient Inversion: Attacks, Defenses and Future Directions](https://www.ijcai.org/proceedings/2022/0791.pdf) – comprehensive overview of gradient inversion strategies and mitigations.
+

--- a/docs_files.txt
+++ b/docs_files.txt
@@ -77,6 +77,8 @@ docs/zero-day-resources-2026.md
 docs/zero-day-resources-2027.md
 docs/training-alignment/reinforcement-learning-attack-discovery.md
 docs/optimization/gradient-resources-2026.md
+docs/optimization/gradient-resources-2027.md
+docs/optimization/gradient-resources-2028.md
 docs/social-engineering/emotional-manipulation-resources.md
 docs/api-level/api-level-attack-resources.md
 docs/token-level/token-prediction-resources.md

--- a/index.json
+++ b/index.json
@@ -609,6 +609,20 @@
       "date_collected": "2025-06-18"
     },
     {
+      "title": "Gradient Attack Resources 2027",
+      "path": "optimization/gradient-resources-2027.md",
+      "category": "Optimization",
+      "sub_category": "",
+      "date_collected": "2025-06-18"
+    },
+    {
+      "title": "Gradient Attack Resources 2028",
+      "path": "optimization/gradient-resources-2028.md",
+      "category": "Optimization",
+      "sub_category": "",
+      "date_collected": "2025-06-19"
+    },
+    {
       "title": "PIG: Privacy Jailbreak via Gradient-based In-Context Optimization",
       "path": "optimization/pig-jailbreak.md",
       "category": "Optimization",

--- a/sbom.json
+++ b/sbom.json
@@ -1394,6 +1394,60 @@
     },
     {
       "type": "file",
+      "name": "optimization/gradient-resources-2027.md",
+      "bom-ref": "optimization/gradient-resources-2027.md",
+      "properties": [
+        {
+          "name": "title",
+          "value": "Gradient Attack Resources 2027"
+        },
+        {
+          "name": "category",
+          "value": "Optimization"
+        },
+        {
+          "name": "source_url",
+          "value": ""
+        },
+        {
+          "name": "date_collected",
+          "value": "2025-06-18"
+        },
+        {
+          "name": "license",
+          "value": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "file",
+      "name": "optimization/gradient-resources-2028.md",
+      "bom-ref": "optimization/gradient-resources-2028.md",
+      "properties": [
+        {
+          "name": "title",
+          "value": "Gradient Attack Resources 2028"
+        },
+        {
+          "name": "category",
+          "value": "Optimization"
+        },
+        {
+          "name": "source_url",
+          "value": ""
+        },
+        {
+          "name": "date_collected",
+          "value": "2025-06-19"
+        },
+        {
+          "name": "license",
+          "value": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "file",
       "name": "optimization/open-sesame-ga.md",
       "bom-ref": "optimization/open-sesame-ga.md",
       "properties": [


### PR DESCRIPTION
## Summary
- add `gradient-resources-2028.md` with new gradient inversion papers
- list new file in docs navigation map, docs_files, index, and sbom

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after network block)*

------
https://chatgpt.com/codex/tasks/task_e_6854390a262c83209044bc779fd66b3d