### PR TITLE
Add gradient resources 2029

### DIFF
--- a/docs/navigation-map.md
+++ b/docs/navigation-map.md
@@ -122,6 +122,7 @@ Primary source articles grouped by theme. Markdown files include YAML front matt
 - `gradient-resources-2026.md` — additional gradient-based jailbreak research
 - `gradient-resources-2027.md` — further gradient-based jailbreak references
 - `gradient-resources-2028.md` — latest gradient-based jailbreak studies
+- `gradient-resources-2029.md` — recent gradient-based jailbreak updates
 - `evolutionary-algorithm-attacks.md` — overview of GA-based jailbreak techniques
 - `boosting-jailbreak-with-momentum.md` — momentum-based gradient attack
 - `dager-gradient-inversion.md` — exact gradient inversion method

--- a/docs/optimization/gradient-resources-2029.md
+++ b/docs/optimization/gradient-resources-2029.md
@@ -1,0 +1,18 @@
+---
+title: "Gradient Attack Resources 2029"
+category: "Optimization"
+source_url: ""
+date_collected: 2025-06-20
+license: "CC-BY-4.0"
+---
+
+The following publications and articles extend the repository's coverage of gradient-based jailbreak techniques and defences.
+
+- [Accelerating Greedy Coordinate Gradient and General Prompt Optimization via Probe Sampling](https://arxiv.org/abs/2403.01251) – proposes probe sampling to speed up gradient-guided jailbreak optimizers.
+- [Prismatic Synthesis: Gradient-based Data Diversification Boosts Generalization in LLM Reasoning](https://arxiv.org/abs/2505.20161) – uses gradient-driven augmentation to improve reasoning robustness.
+- [Unlearning in- vs. out-of-distribution data in LLMs under gradient-based method](https://arxiv.org/abs/2411.04388) – explores selectively unlearning harmful data via gradient updates.
+- [G-DIG: Towards Gradient-based DIverse and hiGh-quality Instruction Data Selection for Machine Translation](https://aclanthology.org/2024.acl-long.821/) – applies gradient signals to curate instruction data.
+- [Exploiting the Index Gradients for Optimization-Based Jailbreaking on Large Language Models](https://arxiv.org/abs/2412.08615) – exploits index gradients for more powerful attacks.
+- [PIG: Privacy Jailbreak Attack on LLMs via Gradient-based Iterative In-Context Optimization (review)](https://www.themoonlight.io/en/review/pig-privacy-jailbreak-attack-on-llms-via-gradient-based-iterative-in-context-optimization) – independent summary and analysis of the PIG attack.
+- [Exploring Index Gradient Jailbreaking (review)](https://www.themoonlight.io/en/review/exploiting-the-index-gradients-for-optimization-based-jailbreaking-on-large-language-models) – commentary on index gradient techniques.
+- [Implement LLM Jailbreak Attack · Armory Library Issue #181](https://github.com/twosixlabs/armory-library/issues/181) – discussion of integrating gradient attacks into an open-source security framework.


### PR DESCRIPTION
## Summary
- add a new page with gradient-based attack resources for 2029
- link the page in navigation-map

## Testing
- `pytest -q` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68544034aee48320a9328cbdf1a64eff