### PR TITLE
Add Puzzler references and patch broken links

### DIFF
--- a/docs/prompt-dialogue/puzzler-attack-resources-2029.md
+++ b/docs/prompt-dialogue/puzzler-attack-resources-2029.md
@@ -13,3 +13,16 @@ The references below extend the existing catalog with new materials on the **Puz
 - [Chinese Blog on Puzzler](https://blog.csdn.net/weixin_57128596/article/details/145077494) – detailed walkthrough in Mandarin explaining the attack steps.
 - [Foundation-Model Paper Notes](https://github.com/NY1024/Foundation-Model-Paper-Notes/blob/master/llm-attack/play-guessing-game-with-llm-indirect-jailbreak-attack-with-implicit.md) – community notes summarizing the Puzzler methodology.
 - [Harvard ADS Abstract](https://ui.adsabs.harvard.edu/abs/2024arXiv240209091C/abstract) – index entry referencing the Puzzler paper.
+
+Additional references covering follow‑on research and community resources:
+
+- [Jigsaw Puzzles: Splitting Harmful Questions to Jailbreak Large Language Models](https://arxiv.org/abs/2410.11459) – multi‑turn jailbreak that cites Puzzler as related work.
+- [Jailbreaking to Jailbreak](https://arxiv.org/abs/2502.09638) – explores puzzle‑style prompts referencing the Puzzler strategy.
+- [WordGame: Efficient & Effective LLM Jailbreak via Simultaneous Obfuscation in Query and Response](https://arxiv.org/abs/2405.14023) – contrasts obfuscation attacks with Puzzler.
+- [SelfDefend: LLMs Can Defend Themselves against Jailbreaking in a Practical Manner](https://arxiv.org/abs/2406.05498) – evaluates defenses against indirect attacks like Puzzler.
+- [Efficient Indirect LLM Jailbreak via Multimodal-LLM Jailbreak](https://arxiv.org/abs/2405.20015) – demonstrates multimodal prompts inspired by Puzzler.
+- [PBI-Attack: Prior-Guided Bimodal Interactive Black-Box Jailbreak Attack for Toxicity Maximization](https://doi.org/10.18653/v1/2025.trustnlp-main.3) – compares its effectiveness with Puzzler prompts.
+- [Exploiting the Index Gradients for Optimization-Based Jailbreaking on Large Language Models](https://www.semanticscholar.org/paper/eeeabe8e2a5dd69089589e910009b3e13c031c58) – includes experiments with Puzzler-style inputs.
+- [Here Comes The AI Worm: Unleashing Zero-click Worms that Target GenAI-Powered Applications](https://www.semanticscholar.org/paper/e6ad241ce87fe608241e9004f4c9d199b6bfebc7) – references Puzzler in broader jailbreak discussions.
+- [CARES: Comprehensive Evaluation of Safety and Adversarial Robustness in Medical LLMs](https://www.semanticscholar.org/paper/15b8ead2bf17a7cc36bbe68b1830a46107ab43e6) – measures defensive performance against attacks including Puzzler.
+- [Leveraging the Context through Multi-Round Interactions for Jailbreaking Attacks](https://www.semanticscholar.org/paper/1b95053af03b5a06809a4967c6cf5ca137bbcde4) – extends the clue‑based approach introduced by Puzzler.

--- a/docs/zero-day-resources-2027.md
+++ b/docs/zero-day-resources-2027.md
@@ -9,9 +9,9 @@ license: "CC-BY-4.0"
 The references below supplement [zero-day-resources.md](zero-day-resources.md) with newly published research papers, competitions, and tools focused on discovering or exploiting zero-day vulnerabilities in systems built with large language models.
 
 - [Artificial Intelligence Cyber Challenge (AIxCC)](https://aicyberchallenge.com/)
-- [AIxCC Rules v5 (PDF)](https://aicyberchallenge.com/storage/2024/03/AIxCC-Rules-v5.pdf)
+- [AIxCC Rules v5 (PDF)](https://web.archive.org/web/20240707193620/https://aicyberchallenge.com/storage/2024/03/AIxCC-Rules-v5.pdf)
 - [Fuzzing BusyBox: Leveraging LLM and Crash Reuse for Embedded Bug Unearthing](http://arxiv.org/abs/2403.03897)
-- [When Fuzzing Meets LLMs: Challenges and Opportunities](https://doi.org/10.1145/3663529.3663784)
+- [When Fuzzing Meets LLMs: Challenges and Opportunities](https://web.archive.org/web/20240506043214/https://dl.acm.org/doi/10.1145/3663529.3663784)
 - [Large Language Model guided Protocol Fuzzing](https://doi.org/10.14722/ndss.2024.24556)
 - [Effective and Evasive Fuzz Testing-Driven Jailbreaking Attacks against LLMs](http://arxiv.org/abs/2409.14866)
 - [Fuzz4All: Universal Fuzzing with Large Language Models](https://doi.org/10.1145/3597503.3639121)

--- a/link_archive.json
+++ b/link_archive.json
@@ -116,11 +116,21 @@
   "https://arxiv.org/abs/2309.01446": {
     "snapshot": "https://web.archive.org/web/20250618/arxiv230901446"
   },
-  "https://arxiv.org/abs/2506.12880": {"snapshot": "https://web.archive.org/web/20250618/arxiv250612880"},
-  "https://arxiv.org/abs/2503.08216": {"snapshot": "https://web.archive.org/web/20250618/arxiv250308216"},
-  "https://arxiv.org/abs/2504.05605": {"snapshot": "https://web.archive.org/web/20250618/arxiv250405605"},
-  "https://arxiv.org/abs/2410.23678": {"snapshot": "https://web.archive.org/web/20250618/arxiv241023678"},
-  "https://arxiv.org/abs/2208.04946": {"snapshot": "https://web.archive.org/web/20250618/arxiv220804946"},
+  "https://arxiv.org/abs/2506.12880": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv250612880"
+  },
+  "https://arxiv.org/abs/2503.08216": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv250308216"
+  },
+  "https://arxiv.org/abs/2504.05605": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv250405605"
+  },
+  "https://arxiv.org/abs/2410.23678": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv241023678"
+  },
+  "https://arxiv.org/abs/2208.04946": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv220804946"
+  },
   "https://skylion007.github.io/OpenWebTextCorpus/": {
     "snapshot": "https://web.archive.org/web/20250618/skylion-openwebtext"
   },
@@ -204,17 +214,44 @@
   },
   "https://thehackernews.com/2025/01/new-ai-jailbreak-method-bad-likert.html": {
     "snapshot": "https://web.archive.org/web/20250618/thn-bad-likert"
+  },
+  "https://arxiv.org/abs/2402.08567": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv240208567"
+  },
+  "https://arxiv.org/abs/2406.04031": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv240604031"
+  },
+  "https://arxiv.org/abs/2411.18000": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv241118000"
+  },
+  "https://arxiv.org/abs/2409.06726": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv240906726"
+  },
+  "https://arxiv.org/abs/2411.11496": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv241111496"
+  },
+  "https://arxiv.org/abs/2411.16721": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv241116721"
+  },
+  "https://arxiv.org/abs/2412.17544": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv241217544"
+  },
+  "https://arxiv.org/abs/2405.12523": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv240512523"
+  },
+  "https://arxiv.org/abs/2405.04403": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv240504403"
+  },
+  "https://arxiv.org/abs/2406.07057": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv240607057"
+  },
+  "https://arxiv.org/abs/2502.06390": {
+    "snapshot": "https://web.archive.org/web/20250618/arxiv250206390"
+  },
+  "https://web.archive.org/web/20240707193620/https://aicyberchallenge.com/storage/2024/03/AIxCC-Rules-v5.pdf": {
+    "snapshot": "https://web.archive.org/web/20240707193620/https://aicyberchallenge.com/storage/2024/03/AIxCC-Rules-v5.pdf"
+  },
+  "https://web.archive.org/web/20240506043214/https://dl.acm.org/doi/10.1145/3663529.3663784": {
+    "snapshot": "https://web.archive.org/web/20240506043214/https://dl.acm.org/doi/10.1145/3663529.3663784"
   }
-  ,
-  "https://arxiv.org/abs/2402.08567": {"snapshot": "https://web.archive.org/web/20250618/arxiv240208567"},
-  "https://arxiv.org/abs/2406.04031": {"snapshot": "https://web.archive.org/web/20250618/arxiv240604031"},
-  "https://arxiv.org/abs/2411.18000": {"snapshot": "https://web.archive.org/web/20250618/arxiv241118000"},
-  "https://arxiv.org/abs/2409.06726": {"snapshot": "https://web.archive.org/web/20250618/arxiv240906726"},
-  "https://arxiv.org/abs/2411.11496": {"snapshot": "https://web.archive.org/web/20250618/arxiv241111496"},
-  "https://arxiv.org/abs/2411.16721": {"snapshot": "https://web.archive.org/web/20250618/arxiv241116721"},
-  "https://arxiv.org/abs/2412.17544": {"snapshot": "https://web.archive.org/web/20250618/arxiv241217544"},
-  "https://arxiv.org/abs/2405.12523": {"snapshot": "https://web.archive.org/web/20250618/arxiv240512523"},
-  "https://arxiv.org/abs/2405.04403": {"snapshot": "https://web.archive.org/web/20250618/arxiv240504403"},
-  "https://arxiv.org/abs/2406.07057": {"snapshot": "https://web.archive.org/web/20250618/arxiv240607057"},
-  "https://arxiv.org/abs/2502.06390": {"snapshot": "https://web.archive.org/web/20250618/arxiv250206390"}
 }


### PR DESCRIPTION
## Summary
- add new references for puzzler attacks
- update zero-day resources links and link archive

## Testing
- `FAST_LINK_CHECK=5 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854402622988320b60c89b13e0fc538