### PR TITLE
Add more LLM supply chain references

### DIFF
--- a/docs/navigation-map.md
+++ b/docs/navigation-map.md
@@ -161,6 +161,7 @@ Primary source articles grouped by theme. Markdown files include YAML front matt
 - `llm-supply-chain-attacks.md` — overview of supply chain risks
 - `poisoned-pretraining-markets.md` — resources on poisoned dataset marketplaces
 - `extended-llm-supply-chain-resources.md` — additional references on supply chain threats
+- `more-llm-supply-chain-resources.md` — further resources gathered after the initial publication
 
 ### token-level/
 - `techradar-tokenbreak.html` — token level manipulation article

--- a/docs/supply-chain/extended-llm-supply-chain-resources.md
+++ b/docs/supply-chain/extended-llm-supply-chain-resources.md
@@ -13,5 +13,6 @@ The following articles and reports provide additional insight into supply-chain 
 - [Supply chain attacks and LLMs](https://www.fortinet.com/blog/security/supply-chain-attacks-and-llms) reviews recent incidents where malicious packages compromised AI tooling.
 - [LLM supply chain security risks research](https://www.securityweek.com/llm-supply-chain-security-risks-research/) summarizes findings from the infosec community on securing model artefacts.
 - [NIST AI Supply Chain Guidance](nist-ai-supply-chain-guidance.pdf) covers government recommendations for securing AI model pipelines.
+- [More LLM Supply Chain Resources](more-llm-supply-chain-resources.md) collects additional articles and best practices discovered after this page was compiled.
 
 These references expand on the threats described in [LLM Supply Chain Attacks](llm-supply-chain-attacks.md) and highlight mitigation steps ranging from rigorous dependency scanning to verifying pre-trained model signatures.

--- a/docs/supply-chain/more-llm-supply-chain-resources.md
+++ b/docs/supply-chain/more-llm-supply-chain-resources.md
@@ -1,0 +1,20 @@
+---
+title: "More LLM Supply Chain Resources"
+category: "Supply Chain"
+date_collected: 2025-06-19
+license: "CC-BY-4.0"
+---
+
+The following additional references expand on supply-chain vulnerabilities affecting large language model development and deployment.
+
+- [OWASP LLM05 Supply Chain Vulnerabilities](https://genai.owasp.org/llmrisk2023-24/llm05-supply-chain-vulnerabilities/) summarizes the risks enumerated in the OWASP Generative AI Security Top 10.
+- [Software Supply Chain Vulnerabilities in LLMs](https://www.practical-devsecops.com/software-supply-chain-vulnerabilities-llms/) explains how dependencies in AI projects are prime targets for attackers.
+- [F5 Knowledge Base on LLM Supply Chain Attacks](https://community.f5.com/kb/security-insights/ai-security--owasp-llm-top-10-2025-and-llm0602-supply-chain-attack/340056) provides defensive guidance for enterprises deploying LLM services.
+- [AI-Generated Code and Supply Chain Risks](https://arstechnica.com/security/2025/04/ai-generated-code-could-be-a-disaster-for-the-software-supply-chain-heres-why/) details how automated coding can introduce malicious packages.
+- [Awesome LLM Supply Chain Security](https://github.com/ShenaoW/awesome-llm-supply-chain-security) is a curated list of tools and papers focused on securing model pipelines.
+- [LLM Supply Chain Attack Prevention Strategies](https://www.cobalt.io/blog/llm-supply-chain-attack-prevention-strategies) outlines proactive measures for DevSecOps teams.
+- [Survey on Securing LLM Supply Chains](https://arxiv.org/html/2410.21218v1) reviews emerging threats and open research questions.
+- [Hallucinated Packages Fuel Supply Chain Attacks](https://www.infoworld.com/article/3542884/large-language-models-hallucinating-non-existent-developer-packages-could-fuel-supply-chain-attacks.html) warns about LLMs inventing fake dependencies that may lead to compromise.
+- [F5 Article K000149634](https://my.f5.com/manage/s/article/K000149634) discusses detection and mitigation of supply chain threats to AI workloads.
+
+These sources complement the existing [Extended LLM Supply Chain Resources](extended-llm-supply-chain-resources.md) file and offer further background for defenders seeking to audit training data, model artifacts, and build pipelines.


### PR DESCRIPTION
## Summary
- add new `more-llm-supply-chain-resources.md` with recent references
- cross-link it from the existing extended resource page
- update the navigation map

## Testing
- `pre-commit run --files docs/supply-chain/more-llm-supply-chain-resources.md docs/supply-chain/extended-llm-supply-chain-resources.md docs/navigation-map.md` *(fails: prompts for GitHub credentials)*
- `pytest -q` *(fails: KeyboardInterrupt after 284s)*

------
https://chatgpt.com/codex/tasks/task_e_68544028acdc832090af90c30b8c8806