### PR TITLE
Add gradient-based resource list for 2031

### DIFF
--- a/docs/navigation-map.md
+++ b/docs/navigation-map.md
@@ -126,6 +126,7 @@ Primary source articles grouped by theme. Markdown files include YAML front matt
 - `gradient-resources-2028.md` — latest gradient-based jailbreak studies
 - `gradient-resources-2029.md` — recent gradient-based jailbreak updates
 - `gradient-resources-2030.md` — newest gradient-based jailbreak materials
+- `gradient-resources-2031.md` — latest gradient-based attack and defense papers
 - `evolutionary-algorithm-attacks.md` — overview of GA-based jailbreak techniques
 - `evolutionary-resources-2030.md` — newly documented GA-based attacks
 - `boosting-jailbreak-with-momentum.md` — momentum-based gradient attack

--- a/docs/optimization/gradient-resources-2031.md
+++ b/docs/optimization/gradient-resources-2031.md
@@ -1,0 +1,17 @@
+---
+title: "Gradient Attack Resources 2031"
+category: "Optimization"
+source_url: ""
+date_collected: 2025-06-21
+license: "CC-BY-4.0"
+---
+
+The following papers and articles extend the catalog with gradient-based jailbreak and defense research published after the 2030 list.
+
+- [Boosting Gradient Leakage Attacks: Data Reconstruction in Realistic FL Settings](https://arxiv.org/abs/2506.08435) – demonstrates advanced gradient inversion for federated learning scenarios.
+- [Zer0-Jack: A Memory-efficient Gradient-based Jailbreaking Method for Black-box Multi-modal Large Language Models](https://arxiv.org/abs/2411.07559) – proposes a lightweight gradient attack for multimodal systems.
+- [Jailbreak Attack Initializations as Extractors of Compliance Directions](https://arxiv.org/abs/2502.09755) – shows how gradient-based initialization uncovers latent "compliance" vectors.
+- [Exploring Gradient-Guided Masked Language Model to Detect Textual Adversarial Attacks](https://arxiv.org/abs/2504.08798) – uses gradient signals to catch adversarial prompts.
+- [FlipAttack: Jailbreak LLMs via Flipping](https://openreview.net/forum?id=H6UMc5VS70) – openreview submission introducing a token-flip gradient technique.
+- [Gradient-based Jailbreak Images for Multimodal Fusion Models](https://openreview.net/forum?id=wNg0LibmQt) – extends arXiv work with additional evaluation material.
+- [Gradient-based Jailbreak Attacks (GitHub Repository)](https://github.com/qizhangli/Gradient-based-Jailbreak-Attacks) – open-source collection of optimization scripts.


### PR DESCRIPTION
## Summary
- add new doc `gradient-resources-2031.md` with recent gradient-based attack references
- link the new doc from `navigation-map.md`

## Testing
- `pytest tests/test_sbom.py -q`
- `pytest tests/test_link_check.py -q` *(fails: KeyboardInterrupt due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6854458dde788320840fd8c0f5ccb09c