### PR TITLE
Add 2033 prompt engineering resources

### DIFF
--- a/docs/additional-resources.md
+++ b/docs/additional-resources.md
@@ -244,3 +244,4 @@ These references track emerging threats and defence research through 2026 and ar
 - [Emotional Manipulation Attack Resources 2027](social-engineering/emotional-manipulation-resources-2027.md)
 - [Prompt Engineering Attack Resources 2031](prompt-dialogue/prompt-engineering-resources-2031.md)
 - [Neuron-Level Manipulation Resources 2033](neuron-resources-2033.md)
+- [Prompt Engineering Attack Resources 2033](prompt-dialogue/prompt-engineering-resources-2033.md)

--- a/docs/prompt-dialogue/prompt-engineering-resources-2033.md
+++ b/docs/prompt-dialogue/prompt-engineering-resources-2033.md
@@ -1,0 +1,23 @@
+---
+title: "Prompt Engineering Attack Resources 2033"
+category: "Prompt Dialogue"
+source_url: ""
+date_collected: 2025-06-19
+license: "CC-BY-4.0"
+---
+
+The references below extend the catalog with additional articles and research papers focused on prompt injection and jailbreak techniques published after the 2032 snapshot.
+
+- [DataSentinel: A Game-Theoretic Detection of Prompt Injection Attacks](https://arxiv.org/abs/2504.11358)
+- [Soft Begging: Modular and Efficient Shielding of LLMs against Prompt Injection and Jailbreaking based on Prompt Tuning](https://arxiv.org/abs/2407.03391)
+- [JailbreakHunter: A Visual Analytics Approach for Jailbreak Prompts Discovery from Large-Scale Human-LLM Conversational Datasets](https://arxiv.org/abs/2407.03045)
+- [Semantic Mirror Jailbreak: Genetic Algorithm Based Jailbreak Prompts Against Open-source LLMs](https://arxiv.org/abs/2402.14872)
+- [SeqAR: Jailbreak LLMs with Sequential Auto-Generated Characters](https://arxiv.org/abs/2407.01902)
+- [SafeInt: Shielding Large Language Models from Jailbreak Attacks via Safety-Aware Representation Intervention](https://arxiv.org/abs/2502.15594)
+- [JBShield: Defending Large Language Models from Jailbreak Attacks through Activated Concept Analysis and Manipulation](https://arxiv.org/abs/2502.07557)
+- [SoK: Evaluating Jailbreak Guardrails for Large Language Models](https://arxiv.org/abs/2506.10597)
+- [Prompt Injection](https://doi.org/10.61608/9783775757027-002)
+- [Virtual Context: Enhancing Jailbreak Attacks with Special Token Injection](https://arxiv.org/abs/2406.19845)
+- [Adversarial Attack on Large Language Models using Exponentiated Gradient Descent](https://arxiv.org/abs/2505.09820)
+- [GeneBreaker: Jailbreak Attacks against DNA Language Models with Pathogenicity Guidance](https://arxiv.org/abs/2505.23839)
+

--- a/docs_files.txt
+++ b/docs_files.txt
@@ -108,3 +108,4 @@ docs/prompt-dialogue/prompt-engineering-resources-2029.md
 docs/prompt-dialogue/prompt-engineering-resources-2030.md
 docs/token-level/token-level-resources-2029.md
 docs/multimodal/visual-jailbreaking-resources-2031.md
+docs/prompt-dialogue/prompt-engineering-resources-2033.md


### PR DESCRIPTION
## Summary
- add new prompt engineering references for 2033
- reference the new document in `additional-resources.md`
- list the file in `docs_files.txt`

## Testing
- `pytest -q tests/test_sbom.py`
- `pytest -q tests/test_link_check.py` *(fails: KeyboardInterrupt)*
- `pre-commit run --files docs/prompt-dialogue/prompt-engineering-resources-2033.md docs/additional-resources.md docs_files.txt index.json` *(fails: requires GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_685443055eb88320b7f4ed64f4535887