### PR TITLE
Add 2029 gradient resources

### DIFF
--- a/docs/navigation-map.md
+++ b/docs/navigation-map.md
@@ -122,6 +122,7 @@ Primary source articles grouped by theme. Markdown files include YAML front matt
 - `gradient-resources-2026.md` — additional gradient-based jailbreak research
 - `gradient-resources-2027.md` — further gradient-based jailbreak references
 - `gradient-resources-2028.md` — latest gradient-based jailbreak studies
+- `gradient-resources-2029.md` — most recent gradient-based references
 - `evolutionary-algorithm-attacks.md` — overview of GA-based jailbreak techniques
 - `boosting-jailbreak-with-momentum.md` — momentum-based gradient attack
 - `dager-gradient-inversion.md` — exact gradient inversion method

--- a/docs/optimization/gradient-resources-2029.md
+++ b/docs/optimization/gradient-resources-2029.md
@@ -1,0 +1,17 @@
+---
+title: "Gradient Attack Resources 2029"
+category: "Optimization"
+source_url: ""
+date_collected: 2025-06-19
+license: "CC-BY-4.0"
+---
+
+The references below update the gradient-based attack and defense collection with additional material released after the 2028 list.
+
+- [Fast Projected Gradient Jailbreak](https://www.promptfoo.dev/lm-security-db/vuln/fast-projected-gradient-jailbreak-ef10d346) – vulnerability note describing a rapid PGD-style jailbreak.
+- [ASETF: A Novel Method for Jailbreak Attack on LLMs through Translate Suffix Embeddings](https://aclanthology.org/2024.emnlp-main.157/) – demonstrates suffix translation guided by gradients to bypass safety filters.
+- [Making a SOTA Adversarial Attack on LLMs 38× Faster](https://www.haizelabs.com/technology/making-a-sota-adversarial-attack-on-llms-38x-faster) – blog post optimizing gradient calculations for speed.
+- [Gradient-Based Attack Methods Overview](https://apxml.com/courses/intro-llm-red-teaming/chapter-4-advanced-evasion-exfiltration-methods/gradient-based-attack-methods-overview) – training material summarizing key techniques.
+- [Transfer Attacks with Substitute Models](https://apxml.com/courses/intro-llm-red-teaming/chapter-4-advanced-evasion-exfiltration-methods/transfer-attacks-substitute-models) – notes on gradient-guided attacks using alternative LLMs.
+- [ICML 2024 Workshop on Secure and Trustworthy LLMs](https://icml.cc/virtual/2024/workshop/29944) – includes talks on gradient-driven adversarial methods.
+- [Gradient Descent and Projected Gradient Descent Lecture Notes](https://www.chrismusco.com/amlds2025/notes/lecture06.html) – academic lecture explaining PGD for jailbreak optimization.


### PR DESCRIPTION
## Summary
- add gradient attack resources for 2029
- update navigation map

## Testing
- `pre-commit run --files docs/optimization/gradient-resources-2029.md docs/navigation-map.md` *(fails: attempted to fetch remote hooks)*
- `pytest` *(fails: ModuleNotFoundError / network blocks)*

------
https://chatgpt.com/codex/tasks/task_e_685440d753788320978c25496047be36