### PR TITLE
Add gradient-based resources for 2032

### DIFF
--- a/docs/additional-resources.md
+++ b/docs/additional-resources.md
@@ -195,6 +195,7 @@ These references track emerging threats and defence research through 2026 and ar
 - [From LLMs to MLLMs: Exploring the Landscape of Multimodal Jailbreaking](https://arxiv.org/abs/2406.14859)
 - [Virtual Context: Enhancing Jailbreak Attacks with Special Token Injection](https://arxiv.org/abs/2406.19845)
 - [Gradient Attack Resources 2026](optimization/gradient-resources-2026.md)
+- [Gradient Attack Resources 2032](optimization/gradient-resources-2032.md)
 - [Play Guessing Game with LLM: Indirect Jailbreak Attack with Implicit Clues](https://arxiv.org/abs/2402.09091)
 - [SelfDefend: LLMs can Defend Themselves Against Jailbreaking in a Practical Manner](https://arxiv.org/abs/2406.05498)
 - [Jigsaw Puzzles: Splitting Harmful Questions to Jailbreak Large Language Models](https://arxiv.org/abs/2410.11459)

--- a/docs/navigation-map.md
+++ b/docs/navigation-map.md
@@ -127,6 +127,7 @@ Primary source articles grouped by theme. Markdown files include YAML front matt
 - `gradient-resources-2029.md` — recent gradient-based jailbreak updates
 - `gradient-resources-2030.md` — newest gradient-based jailbreak materials
 - `gradient-resources-2031.md` — latest gradient-based attack and defense papers
+- `gradient-resources-2032.md` — additional gradient-based jailbreak research
 - `evolutionary-algorithm-attacks.md` — overview of GA-based jailbreak techniques
 - `evolutionary-resources-2030.md` — newly documented GA-based attacks
 - `boosting-jailbreak-with-momentum.md` — momentum-based gradient attack

--- a/docs/optimization/gradient-resources-2032.md
+++ b/docs/optimization/gradient-resources-2032.md
@@ -1,0 +1,17 @@
+---
+title: "Gradient Attack Resources 2032"
+category: "Optimization"
+source_url: ""
+date_collected: 2025-06-22
+license: "CC-BY-4.0"
+---
+
+The references below highlight gradient-based jailbreak and defense research published after the 2031 list.
+
+- [Wolf Hidden in Sheep's Conversations: Toward Harmless Data-Based Backdoor Attacks for Jailbreaking Large Language Models](https://arxiv.org/abs/2505.17601) – demonstrates how seemingly benign data can be optimized to implant covert jailbreak triggers.
+- [Alignment Under Pressure: The Case for Informed Adversaries When Evaluating LLM Defenses](https://arxiv.org/abs/2505.15738) – argues that gradient-guided attacks reveal vulnerabilities overlooked by naive evaluations.
+- [Why LLM Safety Guardrails Collapse After Fine-tuning: A Similarity Analysis Between Alignment and Fine-tuning Datasets](https://arxiv.org/abs/2506.05346) – uses gradient similarity metrics to explain the failure of safety guardrails.
+- [A Sober Look at Steering Vectors for LLMs](https://www.alignmentforum.org/posts/QQP4nq7TXg89CJGBh/a-sober-look-at-steering-vectors-for-llms) – examines the limitations of gradient-derived steering vectors for controlling model behaviour.
+- [Backdoors as an Analogy for Deceptive Alignment](https://www.alignment.org/blog/backdoors-as-an-analogy-for-deceptive-alignment/) – blog post connecting gradient-based backdoor techniques with larger alignment concerns.
+- [Deep Causal Transcoding: A Framework for Mechanistically Editing Language Models](https://www.alignmentforum.org/posts/fSRg5qs9TPbNy3sm5/deep-causal-transcoding-a-framework-for-mechanistically) – proposes gradient-driven transformations to modify internal representations.
+


### PR DESCRIPTION
## Summary
- add gradient-based attack resources for 2032
- link new resource list from navigation map
- reference the 2032 gradient list in additional resources

## Testing
- `pre-commit` *(fails: Username for 'https://github.com')*
- `pytest -q` *(fails: Username for 'https://github.com')*

------
https://chatgpt.com/codex/tasks/task_e_685452192a008320bb4331aef5132914