### PR TITLE
Add token smuggling resources for context window attacks

### DIFF
--- a/docs/inference/context-window-attacks.md
+++ b/docs/inference/context-window-attacks.md
@@ -76,3 +76,7 @@ These resources detail how manipulating a model's working context can produce ha
 - [LongPO: Long Context Self-Evolution of Large Language Models through Short-to-Long Preference Optimization (OpenReview)](https://openreview.net/forum?id=qTrEq31Shm)
 - [Retrieval meets Long Context Large Language Models (OpenReview)](https://openreview.net/forum?id=xw5nxFWMlo)
 - [InfLLM: Training-Free Long-Context Extrapolation for LLMs with an Efficient Context Memory (OpenReview)](https://openreview.net/forum?id=bTHFrqhASY)
+- [Token Smuggling Attack Explained (Prompt Security Blog)](https://www.promptsecurity.com/blog/token-smuggling-explained)
+- [Token Smuggling for Prompt Injection (Lakera AI)](https://www.lakera.ai/blog/token-smuggling)
+- [Token-Smuggling: The Hidden Threat to A.I. and GPT Models (Hashdork)](https://hashdork.com/token-smuggling/)
+- [AI Guardrail Vulnerability Exposed: How Emoji Smuggling Bypasses LLM Safety Filters (WindowsForum)](https://windowsforum.com/threads/ai-guardrail-vulnerability-exposed-how-emoji-smuggling-bypasses-llm-safety-filters.365061/)

--- a/docs/prompt-dialogue/context-window-attack-resources.md
+++ b/docs/prompt-dialogue/context-window-attack-resources.md
@@ -79,3 +79,7 @@ The following sources examine how adversaries exploit an LLM's context window. T
 - [LongPO: Long Context Self-Evolution of Large Language Models through Short-to-Long Preference Optimization (OpenReview)](https://openreview.net/forum?id=qTrEq31Shm)
 - [Retrieval meets Long Context Large Language Models (OpenReview)](https://openreview.net/forum?id=xw5nxFWMlo)
 - [InfLLM: Training-Free Long-Context Extrapolation for LLMs with an Efficient Context Memory (OpenReview)](https://openreview.net/forum?id=bTHFrqhASY)
+- [Token Smuggling Attack Explained (Prompt Security Blog)](https://www.promptsecurity.com/blog/token-smuggling-explained)
+- [Token Smuggling for Prompt Injection (Lakera AI)](https://www.lakera.ai/blog/token-smuggling)
+- [Token-Smuggling: The Hidden Threat to A.I. and GPT Models (Hashdork)](https://hashdork.com/token-smuggling/)
+- [AI Guardrail Vulnerability Exposed: How Emoji Smuggling Bypasses LLM Safety Filters (WindowsForum)](https://windowsforum.com/threads/ai-guardrail-vulnerability-exposed-how-emoji-smuggling-bypasses-llm-safety-filters.365061/)


### PR DESCRIPTION
## Summary
- expand context window attack references to include token smuggling blogs
- mirror additions in `context-window-attacks.md`

## Testing
- `pip install requests pyyaml`
- `pytest tests/test_sbom.py::test_generate_sbom -q`
- `pytest tests/test_link_check.py::test_link_checker -q` *(fails: network blocks)*

------
https://chatgpt.com/codex/tasks/task_e_685445703ab48320b8d0a04bdbdbd928