### PR TITLE
Add latent space resources 2032

### DIFF
--- a/docs/latent-space/latent-space-resources-2032.md
+++ b/docs/latent-space/latent-space-resources-2032.md
@@ -1,0 +1,20 @@
+---
+title: "Latent Space Attack Resources 2032"
+category: "Latent Space"
+source_url: ""
+date_collected: 2025-06-20
+license: "CC-BY-4.0"
+---
+
+The references below highlight additional papers and code repositories focused on latent-state manipulation and embedding inversion.
+
+- [Understanding Refusal in Language Models with Sparse Autoencoders](https://arxiv.org/abs/2505.23556) – analyzes how sparse autoencoders reveal refusal patterns in hidden layers.
+- [Probing Latent Subspaces in LLM for AI Security: Identifying and Manipulating Adversarial States](https://arxiv.org/abs/2503.09066) – studies adversarial directions in representation space.
+- [CeTAD: Towards Certified Toxicity-Aware Distance in Vision Language Models](https://arxiv.org/abs/2503.10661) – proposes a latent-space metric for measuring toxicity risk.
+- [Unnatural Languages Are Not Bugs but Features for LLMs](https://arxiv.org/abs/2503.01926) – explores how atypical prompts exploit hidden representations.
+- [Improving Large Language Model Safety with Contrastive Representation Learning](https://arxiv.org/abs/2506.11938) – uses contrastive objectives to steer latent features away from harmful behaviours.
+- [A look at adversarial attacks on radio waveforms from discrete latent space](https://arxiv.org/abs/2506.09896) – shows how discrete latent attacks transfer to multimodal systems.
+- [Breaking Latent Prior Bias in Detectors for Generalizable AIGC Image Detection](https://arxiv.org/abs/2506.00874) – tackles latent bias to improve diffusion-model detection.
+- [StyleDiffusion](https://github.com/sen-mao/StyleDiffusion) – codebase illustrating style-based diffusion attacks from latent embeddings.
+- [TEIA](https://github.com/coffree0123/TEIA) – repository for multilingual embedding inversion experiments.
+- [IdDecoder](https://github.com/minha12/IdDecoder) – open-source library for reconstructing text from dense vectors.


### PR DESCRIPTION
## Summary
- add new latent-space resource list for 2032 with latest papers and repos

## Testing
- `pre-commit run --files docs/latent-space/latent-space-resources-2032.md` *(failed: requires GitHub credentials)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854436d53e88320b9009d03005e4a60