### PR TITLE
Add 2036 visual jailbreaking references

### DIFF
--- a/docs/multimodal/visual-jailbreaking-resources-2036.md
+++ b/docs/multimodal/visual-jailbreaking-resources-2036.md
@@ -1,0 +1,15 @@
+---
+title: "Visual Jailbreaking Resources 2036"
+category: "Multimodal"
+source_url: ""
+date_collected: 2025-06-25
+license: "CC-BY-4.0"
+---
+
+The references below extend [visual-jailbreaking-resources-2035.md](visual-jailbreaking-resources-2035.md) with newer studies and articles on multimodal and image-based jailbreak techniques.
+
+- [GPT-4 Vision Prompt Injection: Risks, Examples & Defense](https://blog.roboflow.com/gpt-4-vision-prompt-injection/) – overview of visual injection vectors and mitigation strategies.
+- [Prompt injection attacks on vision language models in oncology](https://www.nature.com/articles/s41467-024-55631-x) – investigates the security impact of adversarial images in medical models.
+- [Gradient-based Jailbreak Images for Multimodal Fusion Models](https://openreview.net/forum?id=wNg0LibmQt) – exploits gradient optimization to craft effective jailbreak visuals.
+- [XBreaking: Explainable Artificial Intelligence for Jailbreaking LLMs](https://arxiv.org/abs/2504.21700) – uses explainability methods to discover image-driven exploits.
+- [ASTRA: Steering Away from Harm](https://github.com/ASTRAL-Group/ASTRA) – CVPR 2025 implementation aimed at defending vision-language models from jailbreak prompts.

--- a/docs/navigation-map.md
+++ b/docs/navigation-map.md
@@ -112,6 +112,7 @@ Primary source articles grouped by theme. Markdown files include YAML front matt
 - `visual-jailbreaking-resources-2032.md` — additional resources on recent visual jailbreak research
 - `visual-jailbreaking-resources-2034.md` — follow-up resources on multimodal jailbreaks
 - `visual-jailbreaking-resources-2035.md` — latest visual jailbreak articles and defences
+- `visual-jailbreaking-resources-2036.md` — follow-up research on multimodal jailbreaking
 - `steganography-resources-2026.md` — latest papers on covert LLM attacks
 
 ### optimization/

--- a/docs_files.txt
+++ b/docs_files.txt
@@ -112,6 +112,7 @@ docs/multimodal/visual-jailbreaking-resources-2031.md
 docs/multimodal/visual-jailbreaking-resources-2032.md
 docs/multimodal/visual-jailbreaking-resources-2034.md
 docs/multimodal/visual-jailbreaking-resources-2035.md
+docs/multimodal/visual-jailbreaking-resources-2036.md
 docs/zero-day-resources-2028.md
 docs/zero-day-resources-2032.md
 docs/zero-day-resources-2033.md

--- a/index.json
+++ b/index.json
@@ -1072,6 +1072,20 @@
       "date_collected": "2025-06-19"
     },
     {
+      "title": "Visual Jailbreaking Resources 2035",
+      "path": "multimodal/visual-jailbreaking-resources-2035.md",
+      "category": "Multimodal",
+      "sub_category": "",
+      "date_collected": "2025-06-19"
+    },
+    {
+      "title": "Visual Jailbreaking Resources 2036",
+      "path": "multimodal/visual-jailbreaking-resources-2036.md",
+      "category": "Multimodal",
+      "sub_category": "",
+      "date_collected": "2025-06-25"
+    },
+    {
       "title": "Image-Based LLM Attack Resources 2028",
       "path": "multimodal/image-based-attack-resources-2028.md",
       "category": "Multimodal",


### PR DESCRIPTION
## Summary
- add a new `visual-jailbreaking-resources-2036.md` page
- document additional visual jailbreak references
- update navigation map and docs list
- include 2035 & 2036 resources in `index.json`

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after long wait)*

------
https://chatgpt.com/codex/tasks/task_e_6854d15454e08320840ee1cad782b595