### PR TITLE
Add many-shot gap to secure_v3 matrix

### DIFF
--- a/secure_llmattacks_v3/docs/gap_matrix.md
+++ b/secure_llmattacks_v3/docs/gap_matrix.md
@@ -21,4 +21,5 @@ license: "CC-BY-4.0"
 | Indirect Prompt Injection | HL-INDIRECT | HiddenLayer | ❌ | - |
 | TokenBreak | HL-TOKENBREAK | HiddenLayer | ❌ | - |
 | Homoglyph Obfuscation | HL-HOMOGLYPH | HiddenLayer | ❌ | - |
+| Many-shot Jailbreaking | LLM01 | [Anthropic Research](https://www.anthropic.com/research/many-shot-jailbreaking); [Guardian report](https://www.theguardian.com/technology/2024/apr/03/many-shot-jailbreaking-ai-artificial-intelligence-safety-features-bypass) | ❌ | jailbreaking/many_shot |
 


### PR DESCRIPTION
## Summary
- document many-shot jailbreaking gap in secure_llmattacks_v3

## Testing
- `pytest -q`
- `pre-commit run --files secure_llmattacks_v3/docs/gap_matrix.md` *(fails: command not found or requires network)*

------
https://chatgpt.com/codex/tasks/task_e_685511f9e17c83209437f28324455ade