### PR TITLE
Add length_guard filter

### DIFF
--- a/secure_llmattacks_v3/src/secure_llmattacks_v3/defenses/input_filters/__init__.py
+++ b/secure_llmattacks_v3/src/secure_llmattacks_v3/defenses/input_filters/__init__.py
@@ -1,0 +1,5 @@
+"""Collection of simple input filters used to sanitize text before model calls."""
+
+from .length_guard import abort_if_exceeds
+
+__all__ = ["abort_if_exceeds"]

--- a/secure_llmattacks_v3/src/secure_llmattacks_v3/defenses/input_filters/length_guard.py
+++ b/secure_llmattacks_v3/src/secure_llmattacks_v3/defenses/input_filters/length_guard.py
@@ -1,0 +1,21 @@
+"""Simple token-length guard for input strings."""
+from __future__ import annotations
+
+from typing import Optional
+
+
+MAX_TOKENS = 8192
+
+
+def abort_if_exceeds(text: str, max_tokens: int = MAX_TOKENS) -> Optional[str]:
+    """Return ``text`` unless token count exceeds ``max_tokens``.
+
+    Tokenisation is approximated by whitespace splitting so it works
+    without external dependencies.  If the number of tokens is greater
+    than ``max_tokens`` ``None`` is returned to signal the input should
+    be rejected by the caller.
+    """
+    tokens = text.split()
+    if len(tokens) > max_tokens:
+        return None
+    return text

--- a/secure_llmattacks_v3/tests/test_length_guard.py
+++ b/secure_llmattacks_v3/tests/test_length_guard.py
@@ -1,0 +1,12 @@
+import pytest
+from secure_llmattacks_v3.defenses.input_filters.length_guard import abort_if_exceeds
+
+
+def test_within_limit_returns_text():
+    text = "token" * 100
+    assert abort_if_exceeds(text, max_tokens=200) == text
+
+
+def test_over_limit_returns_none():
+    text = "token " * 10
+    assert abort_if_exceeds(text, max_tokens=5) is None


### PR DESCRIPTION
## Summary
- implement length_guard filter to abort text with too many tokens
- expose in input_filters package
- test length_guard behaviour

## Testing
- `PYTHONPATH=secure_llmattacks_v3/src pytest -q secure_llmattacks_v3/tests/test_length_guard.py`
- `PYTHONPATH=secure_llmattacks_v3/src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551b63364c8320b62a6169bc3f489d