### PR TITLE
Implement length_guard input filter

### DIFF
--- a/defenses/input_filters/__init__.py
+++ b/defenses/input_filters/__init__.py
@@ -1,0 +1,6 @@
+"""Collection of simple input filters used to sanitize text before model calls."""
+
+from .homoglyph import replace_homoglyphs
+from .length_guard import abort_if_exceeds
+
+__all__ = ["replace_homoglyphs", "abort_if_exceeds"]

--- a/defenses/input_filters/length_guard.py
+++ b/defenses/input_filters/length_guard.py
@@ -1,0 +1,15 @@
+"""Simple token-length guard for input strings."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+MAX_TOKENS = 8192
+
+
+def abort_if_exceeds(text: str, max_tokens: int = MAX_TOKENS) -> Optional[str]:
+    """Return ``text`` unless token count exceeds ``max_tokens``."""
+    tokens = text.split()
+    if len(tokens) > max_tokens:
+        return None
+    return text

--- a/tests/test_input_length_guard.py
+++ b/tests/test_input_length_guard.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+# ensure local "defenses" package is imported
+sys.modules.pop("defenses", None)
+sys.modules.pop("defenses.input_filters", None)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from defenses.input_filters.length_guard import abort_if_exceeds
+
+
+def test_within_limit_returns_text():
+    text = "token" * 100
+    assert abort_if_exceeds(text, max_tokens=200) == text
+
+
+def test_over_limit_returns_none():
+    text = "token " * 10
+    assert abort_if_exceeds(text, max_tokens=5) is None


### PR DESCRIPTION
## Summary
- implement a simple token length guard
- export new filter from input_filters package
- add unit tests covering behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551cd0a37c8320ae31abfef1127a71