### PR TITLE
Add CLI options for dataset build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ A searchable website built with **MkDocs Material** is automatically deployed to
 - Run `python scripts/check_duplicates.py` to detect duplicate markdown entries.
 - Run `python scripts/link_check.py` to spot broken links locally.
 - Run `python scripts/refresh_links.py` to update `link_archive.json` with fresh Wayback snapshots.
+- Run `python scripts/build_dataset.py --out-dir datasets/v1 --format parquet` to
+  compile the attacks dataset (use `csv` format if preferred).
 - Broken links are checked via `lychee` in CI.
 - A scheduled workflow refreshes external links weekly and stores Wayback Machine snapshots in `link_archive.json`.
 


### PR DESCRIPTION
## Summary
- add `--out-dir` and `--format` options to `scripts/build_dataset.py`
- include usage example in the script docstring
- mention dataset build command in README

## Testing
- `pre-commit run --files README.md scripts/build_dataset.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855208a84a483208a4ed810c86a2bde