### PR TITLE
Add dataset validation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install black mypy pytest pytest-cov
+      - name: Validate dataset schema
+        run: python scripts/build_dataset.py --check-only
       - name: Black check
         run: black --check .
       - name: Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pdfminer.six",
     "PyYAML",
     "pydantic>=2.0",
+    "pyarrow",
 ]
 
 [tool.black]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ markdownify
 pdfminer.six
 PyYAML
 pydantic>=2.0
+pyarrow


### PR DESCRIPTION
## Summary
- add `pyarrow` as dependency
- enhance `build_dataset.py` with CLI options and `--check-only`
- validate dataset schema in CI on each push
- fix requirements formatting

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/build_dataset.py --check-only`
- `mypy --strict scripts/build_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_685520ad6c78832080417e0422c5fdfd