### PR TITLE
Add CLI options for dataset script

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ A searchable website built with **MkDocs Material** is automatically deployed to
 - Run `python scripts/check_duplicates.py` to detect duplicate markdown entries.
 - Run `python scripts/link_check.py` to spot broken links locally.
 - Run `python scripts/refresh_links.py` to update `link_archive.json` with fresh Wayback snapshots.
+- Run `python scripts/build_dataset.py --out-dir datasets/v1 --format json` to
+  compile all Markdown prompts into `attacks.jsonl`. Use `--format csv` for a
+  CSV file instead.
 - Broken links are checked via `lychee` in CI.
 - A scheduled workflow refreshes external links weekly and stores Wayback Machine snapshots in `link_archive.json`.
 

--- a/secure_llmattacks_v3/README.md
+++ b/secure_llmattacks_v3/README.md
@@ -24,3 +24,13 @@ This workspace provides a trimmed snapshot of the `llmattacks` project focused o
    ```bash
    pytest
    ```
+
+## Dataset Builder
+
+Generate a consolidated attack corpus from the Markdown prompts:
+
+```bash
+python scripts/build_dataset.py --out-dir datasets/v1 --format json
+```
+
+Use `--format csv` to create `attacks.csv` instead of the default `attacks.jsonl`.


### PR DESCRIPTION
## Summary
- add `--out-dir` and `--format` flags to `build_dataset.py`
- document dataset builder in both READMEs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685521d1c0ac83209b5f9d12f9b27a38