### PR TITLE
Add dataset validation step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Run tests
         run: |
           FAST_LINK_CHECK=10 pytest -q --cov=. --cov-report=xml
+      - name: Validate dataset schema
+        run: python scripts/build_dataset.py --check-only
       - name: Mypy
         run: mypy --strict .
       - name: Post coverage comment

--- a/scripts/build_dataset.py
+++ b/scripts/build_dataset.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import uuid
 import unicodedata
 from pathlib import Path
+import argparse
 
 import json
 import yaml
@@ -70,15 +71,39 @@ def gather_samples() -> list[AttackSample]:
     return samples
 
 
-def build_dataset() -> None:
+def build_dataset(out_dir: Path = OUT_DIR) -> int:
     samples = gather_samples()
-    OUT_DIR.mkdir(parents=True, exist_ok=True)
-    with OUT_FILE.open("w", encoding="utf-8") as f:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / OUT_FILE.name
+    with out_file.open("w", encoding="utf-8") as f:
         for sample in samples:
             json.dump(sample.model_dump(), f, ensure_ascii=False)
             f.write("\n")
-    print(f"Wrote {OUT_FILE} ({len(samples)} rows)")
+    print(f"Wrote {out_file} ({len(samples)} rows)")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check-only",
+        action="store_true",
+        help="Validate samples without writing dataset",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=OUT_DIR,
+        help="Output directory for dataset",
+    )
+    args = parser.parse_args()
+
+    samples = gather_samples()
+    if args.check_only:
+        print(f"Validated {len(samples)} samples")
+        return 0
+    return build_dataset(args.out_dir)
 
 
 if __name__ == "__main__":
-    build_dataset()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add CLI options to `build_dataset.py` and a `--check-only` mode
- run dataset schema validation in the CI workflow on every push

## Testing
- `pytest -q`
- `mypy --strict scripts/build_dataset.py`
- `python scripts/build_dataset.py --check-only`

------
https://chatgpt.com/codex/tasks/task_e_68552438de288320826d2b4294911d0a