### PR TITLE
Implement CLI flags for dataset script

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,17 @@ Markdown in the `@extractions1/` directory. URLs already represented in `docs/`
 are skipped automatically. A summary of processed links is written to
 `@extractions1/extraction_log.json`.
 
+## Dataset Generation
+
+Convert the attack examples into a machine‑learning dataset using
+`scripts/build_dataset.py`:
+
+```bash
+python scripts/build_dataset.py --out-dir datasets/v1 --format csv
+```
+
+The `--format` option also accepts `parquet` (requires `pyarrow`).
+
 ## Contributing
 
 Contributions are welcome! Please review [CONTRIBUTING.md](CONTRIBUTING.md) for coding style and front‑matter guidelines. All content must respect the project license and third‑party terms.


### PR DESCRIPTION
## Summary
- add argument parsing to `build_dataset.py`
- support `--out-dir` and `--format {parquet,csv}` options
- document dataset generation in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855241042208320bf4c45403d39b41e