### PR TITLE
Implement dataset check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Run tests
         run: |
           FAST_LINK_CHECK=10 pytest -q --cov=. --cov-report=xml
+      - name: Validate dataset
+        run: python scripts/build_dataset.py --check-only
       - name: Mypy
         run: mypy --strict .
       - name: Post coverage comment

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ Convert the attack examples into a machine‑learning dataset using
 python scripts/build_dataset.py --out-dir datasets/v1 --format csv
 ```
 
-The `--format` option also accepts `parquet` (requires `pyarrow`).
+The `--format` option also accepts `parquet` (requires `pyarrow`). Use
+`--check-only` to validate the dataset without writing any files.
 
 ## Contributing
 

--- a/scripts/build_dataset.py
+++ b/scripts/build_dataset.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """Build the attacks dataset from Markdown, text, and Python files.
 
-Usage:
+Usage::
+
     python scripts/build_dataset.py [--out-dir PATH] [--format {parquet,csv}]
+    python scripts/build_dataset.py --check-only
 """
 
 from __future__ import annotations
@@ -115,5 +117,14 @@ if __name__ == "__main__":
         default="parquet",
         help="output format",
     )
+    parser.add_argument(
+        "--check-only",
+        action="store_true",
+        help="validate dataset without writing output",
+    )
     args = parser.parse_args()
-    build_dataset(out_dir=args.out_dir, fmt=args.format)
+    if args.check_only:
+        samples = gather_samples()
+        print(f"Validated {len(samples)} samples")
+    else:
+        build_dataset(out_dir=args.out_dir, fmt=args.format)


### PR DESCRIPTION
## Summary
- add `--check-only` option to `build_dataset.py`
- mention the flag in README
- run dataset validation step in CI pipeline

## Testing
- `pytest -q`
- `python scripts/build_dataset.py --check-only`


------
https://chatgpt.com/codex/tasks/task_e_68552594daa88320a098b0d386708ad5